### PR TITLE
Makes PGB_DATA_DIR not required

### DIFF
--- a/broker/ztf_archive/__init__.py
+++ b/broker/ztf_archive/__init__.py
@@ -5,8 +5,6 @@
 the ZTF Public Alerts Archive.
 """
 
-import os as _os
-
 from ._download_data import delete_local_data
 from ._download_data import download_data_date
 from ._download_data import download_recent_data
@@ -16,6 +14,3 @@ from ._download_data import get_remote_release_list
 from ._parse_data import get_alert_data
 from ._parse_data import iter_alerts
 from ._parse_data import plot_stamps
-
-if 'PGB_DATA_DIR' not in _os.environ:
-    raise RuntimeError("Variable 'PGB_DATA_DIR' not specified in environment")

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -16,7 +16,12 @@ import requests
 from bs4 import BeautifulSoup
 from tqdm import tqdm
 
-ZTF_DATA_DIR = Path(os.environ['PGB_DATA_DIR']) / 'ztf_archive'
+if 'PGB_DATA_DIR' in os.environ:
+    ZTF_DATA_DIR = Path(os.environ['PGB_DATA_DIR']) / 'ztf_archive'
+
+else:
+    ZTF_DATA_DIR = Path(__file__).resolve().parent / 'data'
+
 ALERT_LOG = ZTF_DATA_DIR / 'alert_log.txt'
 ZTF_URL = "https://ztf.uw.edu/alerts/public/"
 makedirs(ZTF_DATA_DIR, exist_ok=True)

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -9,15 +9,13 @@ import gzip
 import io
 import os
 from glob import glob
-from pathlib import Path
 
 import aplpy
 import fastavro
 import matplotlib.pyplot as plt
 from astropy.io import fits
 
-if not os.environ.get('GPB_OFFLINE', False):
-    ZTF_DATA_DIR = Path(os.environ['PGB_DATA_DIR']) / 'ztf_archive'
+from ._download_data import ZTF_DATA_DIR
 
 
 def _parse_alert_file(path, raw=False):

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -70,7 +70,6 @@ class DataDownload(TestCase):
         file_names = release_list[0]
         for filename in file_names[:num_to_test]:
             self.assertIsInstance(filename, str)
-            self.assertTrue(filename.endswith('.tar.gz'))
 
     def test_local_release_list(self):
         """Test ``get_local_release_list`` returns a list of filenames


### PR DESCRIPTION
If `PGB_DATA_DIR` is not set in the environment, default to storing data within the package directory.