### PR TITLE
Import Context manager and code simplification

### DIFF
--- a/broker/__init__.py
+++ b/broker/__init__.py
@@ -6,20 +6,7 @@ real-time processing for alerts from the  Zwicky Transient Facility (ZTF) and
 the Large Synoptic Survey Telescope (LSST).
 """
 
-import os as _os
-from warnings import warn as _warn
-
 from . import alert_acquisition, data_upload, xmatch, ztf_archive
 from ._gcp_setup import setup_gcp
-
-if 'BROKER_PROJ_ID' not in _os.environ:
-    _warn('GCP project id is not set in the current environment. Please see '
-          'documentation for instructions on setting BROKER_PROJ_ID '
-          'in your environment')
-
-if 'GOOGLE_APPLICATION_CREDENTIALS' not in _os.environ:
-    _warn('GCP credentials path is not set in the current environment. Please '
-          'see documentation for instructions on setting'
-          'GOOGLE_APPLICATION_CREDENTIALS in your environment')
 
 __version__ = '0.1.1'

--- a/broker/alert_acquisition/ztf.py
+++ b/broker/alert_acquisition/ztf.py
@@ -4,16 +4,15 @@
 """Retrieve and parse alerts from the ZTF."""
 
 import json
-import os
 from pathlib import Path
 
 import fastavro
 import pandas as pd
 
-from ..utils import setup_log
+from ..utils import RTDSafeImport, setup_log
 from ..ztf_archive import iter_alerts
 
-if not os.environ.get('GPB_OFFLINE', False):
+with RTDSafeImport():
     from google.cloud import error_reporting
 
     error_client = error_reporting.Client()

--- a/broker/alert_acquisition/ztf.py
+++ b/broker/alert_acquisition/ztf.py
@@ -13,10 +13,7 @@ from ..utils import RTDSafeImport, setup_log
 from ..ztf_archive import iter_alerts
 
 with RTDSafeImport():
-    from google.cloud import error_reporting
-
-    error_client = error_reporting.Client()
-    log = setup_log('ztf_acquisition')
+    error_client, log = setup_log('ztf_acquisition')
 
 SCHEMA_DIR = Path(__file__).resolve().parent / 'schema'
 

--- a/broker/data_upload/_ingest_alerts.py
+++ b/broker/data_upload/_ingest_alerts.py
@@ -11,10 +11,9 @@ import pandavro as pdx
 from ..utils import RTDSafeImport, setup_log
 
 with RTDSafeImport():
-    from google.cloud import error_reporting, bigquery, storage
+    from google.cloud import bigquery, storage
 
-    error_client = error_reporting.Client()
-    log = setup_log('data_upload')
+    error_client, log = setup_log('data_upload')
 
 
 def _get_table_id(data_set, table):

--- a/broker/data_upload/_ingest_alerts.py
+++ b/broker/data_upload/_ingest_alerts.py
@@ -5,6 +5,7 @@
 
 import os
 from tempfile import NamedTemporaryFile
+from warnings import warn
 
 import pandavro as pdx
 
@@ -91,8 +92,7 @@ def _batch_ingest(data, data_set, table):
             raise
 
 
-def upload_to_bigquery(data, data_set, table_name, method='batch',
-                       max_tries=1, verbose=True):
+def upload_to_bigquery(data, data_set, table_name, method='batch', max_tries=1):
     """Batch upload a Pandas DataFrame into a BigQuery table
 
     If the upload fails, retry until success or until max_tries is reached.
@@ -125,9 +125,7 @@ def upload_to_bigquery(data, data_set, table_name, method='batch',
             raise
 
         except Exception as e:
-            if verbose:
-                print(f'Error uploading to table {table_name}: {str(e)}')
-                print('Trying again...')
+            warn(f'Error uploading to table {table_name}. Trying again: {str(e)}')
 
             continue
 

--- a/broker/data_upload/_ingest_alerts.py
+++ b/broker/data_upload/_ingest_alerts.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-"""This module handles the uploading of generic gata into bigquery."""
+"""This module handles the uploading of generic data into bigquery."""
 
 import os
 from tempfile import NamedTemporaryFile
 
 import pandavro as pdx
 
-from ..utils import setup_log
+from ..utils import RTDSafeImport, setup_log
 
-if not os.environ.get('GPB_OFFLINE', False):
+with RTDSafeImport():
     from google.cloud import error_reporting, bigquery, storage
 
     error_client = error_reporting.Client()

--- a/broker/utils.py
+++ b/broker/utils.py
@@ -8,7 +8,6 @@ import logging
 import os
 from pathlib import Path
 
-import google.cloud as gcp
 from google.auth.exceptions import DefaultCredentialsError
 
 
@@ -49,12 +48,14 @@ def setup_log(log_name, level='INFO'):
         A Logger object, or None
     """
 
-    err_client = gcp.error_reporting.Client()
+    from google.cloud import logging as gcp_logging, error_reporting
+
     log = logging.Logger(log_name)
     log.setLevel(level)
 
     # Connect to GCP
-    logging_client = gcp.logging.Client()
+    err_client = error_reporting.Client()
+    logging_client = gcp_logging.Client()
     handler = logging_client.get_default_handler()
     log.addHandler(handler)
 

--- a/broker/utils.py
+++ b/broker/utils.py
@@ -9,6 +9,22 @@ import os
 from pathlib import Path
 
 import google.cloud as gcp
+from google.auth.exceptions import DefaultCredentialsError
+
+
+class RTDSafeImport:
+    """Suppress DefaultCredentialsError when ``GPB_OFFLINE`` is defined
+
+    When ``GPB_OFFLINE`` in the environment, suppress any credential errors and
+    exit. THis allows Read The Docs to build without GCP authentication.
+    """
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_val, traceback):
+        if exc_type == DefaultCredentialsError:
+            return 'GPB_OFFLINE' in os.environ
 
 
 def get_ztf_data_dir():

--- a/broker/utils.py
+++ b/broker/utils.py
@@ -45,9 +45,11 @@ def setup_log(log_name, level='INFO'):
         level    (str): Reporting level for the log
 
     Returns:
+        A GCP error client
         A Logger object, or None
     """
 
+    err_client = gcp.error_reporting.Client()
     log = logging.Logger(log_name)
     log.setLevel(level)
 
@@ -56,4 +58,4 @@ def setup_log(log_name, level='INFO'):
     handler = logging_client.get_default_handler()
     log.addHandler(handler)
 
-    return log
+    return err_client, log

--- a/broker/utils.py
+++ b/broker/utils.py
@@ -33,7 +33,7 @@ def get_ztf_data_dir():
         return Path(os.environ['PGB_DATA_DIR']) / 'ztf_archive'
 
     else:
-        return Path(__file__).resolve().parent / 'data'
+        return Path(__file__).resolve().parent / 'ztf_archive/data'
 
 
 def setup_log(log_name, level='INFO'):

--- a/broker/ztf_archive/__init__.py
+++ b/broker/ztf_archive/__init__.py
@@ -21,6 +21,6 @@ from ._parse_data import iter_alerts
 from ._parse_data import plot_stamps
 
 if 'PGB_DATA_DIR' not in _os.environ:
-    _warn('GCP credentials path is not set in the current environment. Please '
+    _warn('ZTF data directory not set in the current environment. Please '
           'see documentation for instructions on setting'
           'PGB_DATA_DIR in your environment')

--- a/broker/ztf_archive/__init__.py
+++ b/broker/ztf_archive/__init__.py
@@ -5,6 +5,9 @@
 the ZTF Public Alerts Archive.
 """
 
+import os as _os
+from warnings import warn as _warn
+
 from ._download_data import ZTF_URL as archive_url
 from ._download_data import create_ztf_sync_table
 from ._download_data import delete_local_data
@@ -16,3 +19,8 @@ from ._download_data import get_remote_md5_table
 from ._parse_data import get_alert_data
 from ._parse_data import iter_alerts
 from ._parse_data import plot_stamps
+
+if 'PGB_DATA_DIR' not in _os.environ:
+    _warn('GCP credentials path is not set in the current environment. Please '
+          'see documentation for instructions on setting'
+          'PGB_DATA_DIR in your environment')

--- a/broker/ztf_archive/__init__.py
+++ b/broker/ztf_archive/__init__.py
@@ -13,8 +13,8 @@ from ._download_data import create_ztf_sync_table
 from ._download_data import delete_local_data
 from ._download_data import download_data_date
 from ._download_data import download_recent_data
-from ._download_data import get_local_alert_list
-from ._download_data import get_local_release_list
+from ._download_data import get_local_alerts
+from ._download_data import get_local_releases
 from ._download_data import get_remote_md5_table
 from ._parse_data import get_alert_data
 from ._parse_data import iter_alerts

--- a/broker/ztf_archive/_download_data.py
+++ b/broker/ztf_archive/_download_data.py
@@ -81,8 +81,8 @@ def _download_alerts_file(file_name, out_dir, block_size, verbose):
     Args:
         file_name  (str): Name of the file to download
         out_dir    (str): The directory where the file should be downloaded to
-        block_size (int): Block size to use for large files (Default: 1024)
-        verbose   (bool): Display a progress bar (Default: True)
+        block_size (int): Block size to use for large files
+        verbose   (bool): Display a progress bar
     """
 
     # noinspection PyUnresolvedReferences
@@ -116,15 +116,17 @@ def _download_alerts_file(file_name, out_dir, block_size, verbose):
         ofile.write(file_name)
 
 
-def download_data_date(year, month, day, block_size=1024, verbose=False):
+def download_data_date(year, month, day, block_size=1024, verbose=True):
     """Download ZTF alerts for a given date
 
     Does not skip releases that are were previously downloaded.
 
     Args:
-        year  (int): The year of the data to download
-        month (int): The month of the data to download
-        day   (int): The day of the data to download
+        year       (int): The year of the data to download
+        month      (int): The month of the data to download
+        day        (int): The day of the data to download
+        block_size (int): Block size to use for large files (Default: 1024)
+        verbose   (bool): Display a progress bar (Default: True)
     """
 
     file_name = f'ztf_public_{year}{month:02d}{day:02d}.tar.gz'
@@ -135,7 +137,7 @@ def download_data_date(year, month, day, block_size=1024, verbose=False):
 
 
 def download_recent_data(
-        max_downloads=1, stop_on_exist=False, block_size=1024, verbose=False):
+        max_downloads=1, block_size=1024, verbose=True, stop_on_exist=False):
     """Download recent alert data from the ZTF alerts archive
 
     Data is downloaded in reverse chronological order. Skip releases that are
@@ -143,6 +145,8 @@ def download_recent_data(
 
     Args:
         max_downloads  (int): Number of daily releases to download (default: 1)
+        block_size     (int): Block size to use for large files (Default: 1024)
+        verbose       (bool): Display a progress bar (Default: True)
         stop_on_exist (bool): Exit when encountering an alert that is already
                                downloaded (Default: False)
     """
@@ -175,7 +179,7 @@ def delete_local_data():
     ZTF_DATA_DIR.mkdir(exist_ok=True, parents=True)
 
 
-def create_ztf_sync_table(bucket_name=None, out_path=None, verbose=False):
+def create_ztf_sync_table(bucket_name=None, out_path=None, verbose=True):
     """Create a table for uploading ZTF releases to a GCP bucket
 
     Only include files not already present in the bucket
@@ -183,7 +187,7 @@ def create_ztf_sync_table(bucket_name=None, out_path=None, verbose=False):
     Args:
         bucket_name (str): Name of the bucket to upload into
         out_path    (str): Optionally write table to a txt file
-        verbose    (bool): Whether to display a progress bar (Default: False)
+        verbose    (bool): Whether to display a progress bar (Default: True)
     """
 
     from google.cloud import storage

--- a/broker/ztf_archive/_parse_data.py
+++ b/broker/ztf_archive/_parse_data.py
@@ -39,24 +39,24 @@ def _parse_alert_file(path, raw=False):
             return next(fastavro.reader(f))
 
 
-def get_alert_data(candid, raw=False):
+def get_alert_data(alertid, raw=False):
     """Return the contents of an avro file published by ZTF
 
     Args:
-        candid (int): Unique ZTF identifier for the subtraction candidate
-        raw   (bool): Optionally return the file data as bytes (Default: False)
+        alertid (int): Unique ZTF identifier for the alert packet
+        raw    (bool): Optionally return the file data as bytes (Default: False)
 
     Returns:
         The file contents as a dictionary
     """
 
-    path = os.path.join(ZTF_DATA_DIR, f'{candid}.avro')
+    path = os.path.join(ZTF_DATA_DIR, f'{alertid}.avro')
     try:
         return _parse_alert_file(path, raw)
 
     except FileNotFoundError:
         raise ValueError(
-            f'Data for candid "{candid}" not locally available (at {path}).')
+            f'Data for "{alertid}" not locally available (at {path}).')
 
 
 def iter_alerts(num_alerts=None, raw=False):

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -121,6 +121,15 @@ manually, the broker package provides a setup function for convenience.
     # Setup your GCP project
     setup_gcp()
 
+
+Running Offline
+---------------
+
+The ``broker`` package can be instructed to ignore certain tests and imports
+that involve connecting to Google Cloud by defining the ``GPB_OFFLINE``
+variable in your environment. The value of this variable is not considered,
+only whether the variable is defined.
+
 .. _Create a project: https://cloud.google.com/resource-manager/docs/creating-managing-projects
 .. _Authenticate: https://cloud.google.com/docs/authentication/getting-started
 .. _here: https://cloud.google.com/resource-manager/docs/creating-managing-projects

--- a/docs/source/module_docs/ztf_archive.rst
+++ b/docs/source/module_docs/ztf_archive.rst
@@ -11,8 +11,8 @@ broker.ztf_archive
 .. autofunction:: download_data_date
 .. autofunction:: download_recent_data
 .. autofunction:: get_alert_data
-.. autofunction:: get_local_alert_list
-.. autofunction:: get_local_release_list
+.. autofunction:: get_local_alerts
+.. autofunction:: get_local_releases
 .. autofunction:: get_remote_md5_table
 .. autofunction:: iter_alerts
 .. autofunction:: plot_stamps

--- a/docs/source/quick_start/ztf_archive.rst
+++ b/docs/source/quick_start/ztf_archive.rst
@@ -19,8 +19,8 @@ iteratively in reverse chronological order.
    from broker import ztf_archive as ztfa
 
    # Get a list of files available on the ZTF Alerts Archive
-   file_names, file_sizes = ztfa.get_remote_md5_table()
-   print(file_names)
+   md5_table = ztfa.get_remote_md5_table()
+   print(md5_table)
 
    # Download data from the ZTF archive for a given day.
    ztfa.download_data_date(year=2018, month=6, day=26)
@@ -41,7 +41,7 @@ visualizing alert data.
 .. code:: python
 
    # Retrieve the IDs for all alerts downloaded to your local machine
-   alert_ids = ztfa.get_local_alert_list()
+   alert_ids = list(ztfa.get_local_alerts())
    print(alert_ids)
 
    # Get data for a specific alert

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -6,14 +6,14 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase
-
+import types
 from broker import ztf_archive as ztfa
 
 temp_dir = TemporaryDirectory()
 
 # Metadata about the data downloaded by this test
 TEST_DATE = (2018, 6, 26)
-TEST_FILE_NAME = 'ztf_public_20180626.tar.gz'
+TEST_RELEASE = '20180626'
 NUM_TEST_ALERTS = 23553
 
 
@@ -48,24 +48,21 @@ class DownloadLogging(TestCase):
         Check the correct number of alerts are returned
         """
 
-        num_downloaded_alerts = len(ztfa.get_local_alert_list())
-        self.assertEqual(num_downloaded_alerts, NUM_TEST_ALERTS)
+        alert_list = list(ztfa.get_local_alerts())
+        self.assertEqual(len(alert_list), NUM_TEST_ALERTS)
 
     def test_local_release_list(self):
         """Test ``get_local_release_list``
 
         Check ``get_local_release_list`` returns a list
         Check correct file name(s) are in that list
-        Check first list entry is strings and ends with `.tar.gz`
         """
 
-        release_list = ztfa.get_local_release_list()
-        self.assertIsInstance(release_list, list)
+        releases = ztfa.get_local_releases()
+        self.assertIsInstance(releases, types.GeneratorType)
         self.assertSequenceEqual(
-            [TEST_FILE_NAME], release_list,
-            'Expected filename not in local release list')
-
-        self.assertTrue(release_list[0].endswith('.tar.gz'))
+            [TEST_RELEASE], list(releases),
+            'Expected release not in local release list')
 
     def test_local_alert_list(self):
         """Test ``get_local_alert_list``
@@ -75,10 +72,9 @@ class DownloadLogging(TestCase):
         Check first entry is an integer
         """
 
-        alert_list = ztfa.get_local_alert_list()
-        self.assertIsInstance(alert_list, list)
-        self.assertTrue(alert_list)
-        self.assertIsInstance(alert_list[0], int)
+        alerts = ztfa.get_local_alerts()
+        self.assertIsInstance(alerts, types.GeneratorType)
+        self.assertIsInstance(next(alerts), int)
 
 
 class DataParsing(TestCase):
@@ -100,7 +96,7 @@ class DataParsing(TestCase):
     def test_get_alert_data(self):
         """Test ``get_alert_data`` returns the correct data type."""
 
-        test_alert = ztfa.get_local_alert_list()[0]
+        test_alert = next(ztfa.get_local_alerts())
 
         test_data_dict = ztfa.get_alert_data(test_alert)
         self.assertIsInstance(test_data_dict, dict)

--- a/tests/test_ztf_archive.py
+++ b/tests/test_ztf_archive.py
@@ -54,8 +54,8 @@ class DownloadLogging(TestCase):
     def test_local_release_list(self):
         """Test ``get_local_release_list``
 
-        Check ``get_local_release_list`` returns a list
-        Check correct file name(s) are in that list
+        Check ``get_local_release_list`` returns a generator
+        Check correct releases are in that list
         """
 
         releases = ztfa.get_local_releases()
@@ -67,8 +67,7 @@ class DownloadLogging(TestCase):
     def test_local_alert_list(self):
         """Test ``get_local_alert_list``
 
-        Check the return a list
-        Check the list is not empty
+        Check the return a generator
         Check first entry is an integer
         """
 


### PR DESCRIPTION
This PR simplifies the logic of existing functions in the `ztf_archive` module. As part of this change,  I've added the `RTDSafeImport` context manager to handel GCP imports in the RTD environment. 