### PR TITLE
Add component integration tests

### DIFF
--- a/tests/component_tests/README.md
+++ b/tests/component_tests/README.md
@@ -1,0 +1,19 @@
+# Component Tests
+
+This directory contains all files needed to run the tests described below.
+
+## Objective
+
+Test that each component responds to its trigger (usually a Pub/Sub stream) is correctly integrated with the broker's data resources:
+
+- Pub/Sub (component's trigger topic and output topic(s))
+- BigQuery (output table(s))
+- Cloud Storage (output bucket(s)), and runs successfully end-to-end when messages are published to the component's trigger topic (Pub/Sub).
+
+## Steps
+
+1. Send Input: Publish a fixed set of messages to the component's trigger topic (Pub/Sub stream).
+
+1. Component Processing (we are testing that this happens automatically, as expected): The component should accept the messages, process them, and write output data to Pub/Sub, BigQuery, and/or Cloud Storage)
+
+1. Check Output: Check the relevant Pub/Sub, BigQuery, and/or Cloud Storage resources for the output data. Validate that it is as expected.

--- a/tests/component_tests/cloud_run/README.md
+++ b/tests/component_tests/cloud_run/README.md
@@ -1,0 +1,16 @@
+# Cloud Run Services for Component Tests
+
+This directory contains source code for the Cloud Run services that facilitate component tests, including:
+
+- bucket_to_pubsub: Service that pulls files from a Cloud Storage bucket and publishes them to a Pub/Sub topic, one message per file. The bucket, Pub/Sub topic, and publish format (Avro or JSON) are configurable via the Pub/Sub message used to trigger the service.
+
+- verify_pubsub: Service that verifies messages in its (Pub/Sub) trigger topic by checking that message:
+
+  - attributes contain the expected keys
+  - payload is formatted in the expected way
+  - payload contains the expected keys
+
+## Build container images and push to the registry
+
+This only needs to be done once per GCP project.
+The component-test Workflow will automatically deploy a service using the registry image.

--- a/tests/component_tests/cloud_run/bucket_to_pubsub.py
+++ b/tests/component_tests/cloud_run/bucket_to_pubsub.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""Pull files from a Cloud Storage bucket and publish them to a Pub/Sub topic.
+
+One message per file.
+The bucket, Pub/Sub topic, and publish format (Avro or JSON) are configurable via the
+Pub/Sub message used to trigger the service.
+"""

--- a/tests/component_tests/cloud_run/main.py
+++ b/tests/component_tests/cloud_run/main.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""Pull files from a Storage bucket and publish to a Pub/Sub topic."""
+
+import os
+
+from flask import Flask, request
+from google.cloud import logging
+
+from . import bucket_to_pubsub, verify_pubsub
+
+
+app = Flask(__name__)
+
+PROJECT_ID = os.getenv("GCP_PROJECT")
+TESTID = os.getenv("TESTID")
+SURVEY = os.getenv("SURVEY")
+
+# connect to the logger
+logging_client = logging.Client()
+log_name = "component-tests"  # same log for all broker instances
+logger = logging_client.logger(log_name)
+
+
+@app.route("/bucket_to_pubsub", methods=["POST"])
+def run_bucket_to_pubsub_service():
+    """Entry point for the bucket_to_pubsub service."""
+    envelope = request.get_json()
+
+    # verify the message format
+    envelope_error = verify_envelope(envelope)
+    if envelope_error:
+        return envelope_error
+
+    # run the service
+    try:
+        result = bucket_to_pubsub.run(envelope)
+
+    except Exception as e:
+        # return a server error code
+        return (f"{e}", 500)
+
+    else:
+        # return success code along with the result
+        return (result, 200)
+
+
+@app.route("/bucket_to_pubsub", methods=["POST"])
+def run_verify_pubsub_service():
+    """Entry point for the verify_pubsub service."""
+    envelope = request.get_json()
+
+    # verify the message format
+    envelope_error = verify_envelope(envelope)
+    if envelope_error:
+        return envelope_error
+
+    # run the service
+    try:
+        verify_pubsub.run(envelope)
+
+    except Exception as e:
+        # return a server error code
+        return (f"{e}", 500)
+
+    else:
+        # return success code
+        return ("", 204)
+
+
+def verify_envelope(envelope):
+    """Return a 400 code if the envelope format is not as-expected."""
+    envelope_error = None
+
+    # do some checks
+    if not envelope:
+        msg = "no Pub/Sub message received"
+        print(f"error: {msg}")
+        envelope_error = (f"Bad Request: {msg}", 400)
+
+    if not isinstance(envelope, dict) or "message" not in envelope:
+        msg = "invalid Pub/Sub message format"
+        print(f"error: {msg}")
+        envelope_error = (f"Bad Request: {msg}", 400)
+
+    return envelope_error
+
+
+if __name__ == "__main__":
+    PORT = int(os.getenv("PORT")) if os.getenv("PORT") else 8080
+
+    # This is used when running locally. Gunicorn is used to run the
+    # application on Cloud Run. See entrypoint in Dockerfile.
+    app.run(host="127.0.0.1", port=PORT, debug=True)

--- a/tests/component_tests/cloud_run/verify_pubsub.py
+++ b/tests/component_tests/cloud_run/verify_pubsub.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""Verify incoming messages by checking attribute and payload keys."""


### PR DESCRIPTION
Partially addresses #82 

Goal: For each broker component, demonstrate that known input (i.e., a set of test alerts published to the component's trigger topic) produces the expected output data in all public resources: Pub/Sub, BigQuery, Cloud Storage.

This will use GCP Workflows + two Cloud Run services. Here is the plan:

### bucket_to_pubsub service
- Function: pull test alerts from Storage bucket and publish to the component’s Pub/Sub trigger topic
- Inputs (from the triggering Pub/Sub message): storage bucket name, publish topic, publish format (Avro or JSON)
- Returns: List of alerts that were published: `[(objectId, candid), ]`

### validate_pubsub service
- Function: listen to the component’s Pub/Sub output topic, check the message attributes and payload for a given set of keys, write the results to a BigQuery table
- Env vars: message format (Avro or JSON), BigQuery table to write results to, attribute keys to check for, payload keys to check for
- Write results to BigQuery: `objectId`, `candid`, plus bools for each attribute and payload key indicating whether it was found

### Workflows Steps

Step 1 can be done once; the remaining steps are completed for each component

1. Setup bucket_to_pubsub service (see below for details):
    - deploy the service
    - create a topic, and push subscription to the bucket_to_pubsub service
2. Setup validate_pubsub service (see below for details):
    - deploy the service with given env vars
    - create a push subscription from the component’s publish topic to the validate_pubsub service
    - create BQ table(s) for the validate_pubsub service to write to
3. Trigger the bucket_to_pubsub service by sending a Pub/Sub message to its trigger topic
4. Wait for module to execute
5. Read resources (streams via the table validate_pubsub writes to, tables, buckets), compare to list returned by the bucket_to_pubsub service.
6. Report success or failure

### Configs

Main configs (every component):
- bucket name holding set of test alerts

Per component configs:
- Pub/Sub trigger topic
- message format expected (Avro or JSON)
- output resources (dict. example for the purity classifier component):
    - Pub/Sub: `[{"topic": <>, "attrs": [<>, ]`, payload: `{"alert_dicts": {"alert": [objectId, candid], "pure": [is_pure, ]}}}, ]`
    - BigQuery: `[{"table": "classifications", "where": "classifier='purity'"}, {"table": "purity"}, ]`
    - Storage: `[{"bucket": <>, "file_name_syntax": <>}, ]`

### To Do:

- [ ] write a module to run the bucket_to_pubsub service
- [ ] write a module to run the validate_pubsub service
- [ ] write workflows for each component
- [ ] update docs