### PR TITLE
Fix bug in data_utils.open_alert()

### DIFF
--- a/broker/broker_utils/CHANGELOG.md
+++ b/broker/broker_utils/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## \[Unreleased\]<a name="unreleased"></a>
 
+## \[0.2.42\] - 2022-08-24
+
+### Fixed
+
+- Fix bug introduced by allowing `data_utils.open_alert()` to blindly send `**kwargs` to the functions it calls. `data_utils.open_alert()` now sends only the arguments that are appropriate for the function it's calling.
+
 ## \[0.2.41\] - 2022-08-19
 
 ### Fixed

--- a/broker/broker_utils/setup.py
+++ b/broker/broker_utils/setup.py
@@ -31,7 +31,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='pgb_broker_utils',
-    version='0.2.41',
+    version='0.2.42',
     description='Tools used by the Pitt-Google astronomical alert broker.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Fixes the bug referenced by #161.

Previous version of `broker_utils.data_utils.open_alert()` blindly sent `**kwargs` to the functions it called causing the wrong arguments to be sent in some cases. `open_alert()`  now sends only the arguments that are appropriate for the function it's calling.