### PR TITLE
add IAM role `userPublic` to allow `allUsers` to attach subscriptions to topics

### DIFF
--- a/setup/role_user_public.yml
+++ b/setup/role_user_public.yml
@@ -1,0 +1,6 @@
+title: "Public User of Pitt-Google Broker"
+# intended role-id, to be set at deployment: "userPublic"
+description: "Role graning permissions necessary for accessing Pitt-Google's public data resources. Intended to be bound to the `allUsers` member. allUsers is anyone on the internet, no authentication required. However, some individual GCP services will still require authentication."
+stage: "ALPHA"
+includedPermissions:
+- pubsub.topics.attachSubscription

--- a/setup/set_iam_policy.sh
+++ b/setup/set_iam_policy.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+# this is currently only implemented for pubsub topics
+TOPIC="${1}"
+ROLEID="${2:-projects/${GOOGLE_CLOUD_PROJECT}/roles/userPublic}"
+USER="${3:-allUsers}"
+
+# get the current policy
+policy_yaml="current_policy_tmp.yml"
+gcloud pubsub topics get-iam-policy "${TOPIC}" > "${policy_yaml}"
+
+# append the binding
+# if this is the first binding, we need a header
+if [ $(grep "" -c $policy_yaml) -eq "1" ]; then
+    echo "bindings:" >> "${policy_yaml}"
+fi
+echo "- role: ${ROLEID}" >> "${policy_yaml}"
+echo "  members:" >> "${policy_yaml}"
+echo "    - ${USER}" >> "${policy_yaml}"
+
+# set the new policy on the project
+gcloud pubsub topics set-iam-policy "${TOPIC}" "${policy_yaml}"
+
+# cleanup
+rm "${policy_yaml}"

--- a/setup/setup_project.sh
+++ b/setup/setup_project.sh
@@ -10,3 +10,9 @@
         --description="Allow incoming traffic on TCP port 9094" \
         --direction=INGRESS \
         --enable-logging
+
+# Create an IAM role for a public user.
+# this will be used later to grant permissions on specific resources
+role_id="userPublic"
+role_yaml="role_user_public.yml"
+gcloud iam roles create "${role_id}" --project="${GOOGLE_CLOUD_PROJECT}" --file="${role_yaml}"


### PR DESCRIPTION
- Adds an IAM role called `userPublic` to project_setup.sh.
- Updates broker_setup.sh to create policy bindings: `userPublic` role + specific Pub/Sub topics + `allUsers` (everyone on the internet)
- Adds a dedicated script that does the policy binding updates