### PR TITLE
Make ELAsTiCC broker deployable for live stream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ broker/ztf_archive/data/
 
 # Authentication keys
 GCPauth.json
-krb5.conf
 pitt-reader.user.keytab
 
 # OS files

--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ The Pitt-Google broker is an astronomical alert broker that is being developed f
 We currently process and serve the [Zwicky Transient Facility](https://www.ztf.caltech.edu/)'s (ZTF) nightly alert stream.
 The broker runs on the [Google Cloud Platform](https://cloud.google.com) (GCP).
 
-Documentation is at [pitt-broker.readthedocs.io](https://pitt-broker.readthedocs.io/).
+This particular version of the code is running our broker for the ELAsTiCC challenge.
+
+Main documentation is at [pitt-broker.readthedocs.io](https://pitt-broker.readthedocs.io/).
 
 If you run into issues or need assistance, please [open an Issue](https://github.com/mwvgroup/Pitt-Google-Broker/issues).
+
+
+## Usage
+
+To deploy a broker instance, see [setup/README.md](setup/README.md).

--- a/broker/cloud_functions/ps_to_gcs/main.py
+++ b/broker/cloud_functions/ps_to_gcs/main.py
@@ -18,7 +18,7 @@ from google.cloud import storage
 from google.cloud.exceptions import PreconditionFailed
 
 from broker_utils.avro_schemas.load import all as load_all_schemas
-from broker_utils.schema_maps import load_schema_map, get_value, get_key
+from broker_utils.schema_maps import load_schema_map, get_key
 from broker_utils.types import AlertFilename, AlertIds
 from exceptions import SchemaParsingError
 

--- a/broker/consumer/krb5.conf
+++ b/broker/consumer/krb5.conf
@@ -1,0 +1,16 @@
+[logging]
+	default = FILE:/var/log/krb5libs.log
+	kdc = FILE:/var/log/krb5kdc.log
+	admin_server = FILE:/var/log/kadmin.log
+
+[libdefaults]
+	default_realm = KAFKA.SECURE
+	kdc_timesync = 1
+	ticket_lifetime = 24h
+
+[realms]
+	KAFKA.SECURE = {
+		admin_server = public2.alerts.ztf.uw.edu
+		kdc = public2.alerts.ztf.uw.edu
+		default_principal_flags=+renewable
+		}

--- a/broker/consumer/vm_install.sh
+++ b/broker/consumer/vm_install.sh
@@ -26,14 +26,19 @@ if [ "${testid}" != "False" ]; then
     broker_bucket="${broker_bucket}-${testid}"
 fi
 
+#--- Setup the working dir
+# CONNECTION REQUIREMENT: keytab authorization file must be manually uploaded here
+workingdir="/home/broker/consumer"
+mkdir -p "${workingdir}"
+cd "${workingdir}"
+gsutil -m cp -r "gs://${broker_bucket}/consumer/**" .
+
 #--- Install general utils
 apt-get update
 apt-get install -y wget screen software-properties-common snapd
 # software-properties-common installs add-apt-repository
 snap install core
 snap install yq
-
-mkdir -p "/home/broker/consumer"
 
 #--- Install Java and the dev kit
 # see https://www.digitalocean.com/community/tutorials/how-to-install-java-with-apt-on-debian-10
@@ -71,8 +76,9 @@ echo "Done installing the Kafka -> Pub/Sub connector"
 
 #--- Set the startup script and shutdown
 startupscript="gs://${broker_bucket}/consumer/vm_startup.sh"
+shutdownscript="gs://${broker_bucket}/consumer/vm_shutdown.sh"
 gcloud compute instances add-metadata "${consumerVM}" \
     --zone "$zone" \
-    --metadata="startup-script-url=${startupscript}"
+    --metadata="startup-script-url=${startupscript},shutdown-script-url=${shutdownscript}"
 echo "vm_install.sh is complete. Shutting down."
 shutdown -h now

--- a/broker/consumer/vm_install.sh
+++ b/broker/consumer/vm_install.sh
@@ -41,7 +41,7 @@ apt update
 echo "Installing Java..."
 apt install -y default-jre
 apt install -y default-jdk
-echo 'JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64/bin/java"' >> /etc/environment
+echo 'JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"' >> /etc/environment
 source /etc/environment
 echo "${JAVA_HOME}"
 echo "Done installing Java."

--- a/broker/consumer/vm_install.sh
+++ b/broker/consumer/vm_install.sh
@@ -32,6 +32,7 @@ workingdir="/home/broker/consumer"
 mkdir -p "${workingdir}"
 cd "${workingdir}"
 gsutil -m cp -r "gs://${broker_bucket}/consumer/**" .
+mv "krb5.conf" "/etc/krb5.conf"
 
 #--- Install general utils
 apt-get update

--- a/broker/consumer/vm_shutdown.sh
+++ b/broker/consumer/vm_shutdown.sh
@@ -4,7 +4,8 @@
 baseurl="http://metadata.google.internal/computeMetadata/v1"
 H="Metadata-Flavor: Google"
 vm_name=$(curl "${baseurl}/instance/name" -H "${H}")
+zone=$(curl "${baseurl}/instance/zone" -H "${H}")
 
 # Unset topics in metadata so there's no unexpected behvaior on next startup
 topics="KAFKA_TOPIC=,KAFKA_TOPIC_FORCE=,PS_TOPIC=,PS_TOPIC_FORCE="
-gcloud compute instances add-metadata "${vm_name}" --metadata="${topics}"
+gcloud compute instances add-metadata "${vm_name}" --zone "${zone}" --metadata="${topics}"

--- a/broker/consumer/vm_shutdown.sh
+++ b/broker/consumer/vm_shutdown.sh
@@ -5,6 +5,6 @@ baseurl="http://metadata.google.internal/computeMetadata/v1"
 H="Metadata-Flavor: Google"
 vm_name=$(curl "${baseurl}/instance/name" -H "${H}")
 
-# Unset FORCE topics in metadata so there's no unexpected behvaior on next startup
-topics="KAFKA_TOPIC_FORCE=,PS_TOPIC_FORCE="
+# Unset topics in metadata so there's no unexpected behvaior on next startup
+topics="KAFKA_TOPIC=,KAFKA_TOPIC_FORCE=,PS_TOPIC=,PS_TOPIC_FORCE="
 gcloud compute instances add-metadata "${vm_name}" --metadata="${topics}"

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -3,7 +3,11 @@
 
 brokerdir="/home/broker"
 workingdir="${brokerdir}/consumer"
-# mkdir -p ${workingdir} # keytab auth file must already exist in this dir
+# the keytab file required for authorization must already exist in the workingdir.
+# make it immutable, then delete everything else so we can start fresh.
+chattr +i "${workingdir}/pitt-reader.user.keytab"
+rm -rf "${brokerdir}"
+cd "${workingdir}"
 
 #--- Files this script will write
 fout_run="${workingdir}/run-connector.out"
@@ -37,9 +41,6 @@ if [ "$testid" != "False" ]; then
 fi
 
 #--- Download fresh config files from the bucket
-cd "${brokerdir}"
-# remove all consumer files except the keytab
-find "${workingdir}" -type f -not -name 'pitt-reader.user.keytab' -delete
 gsutil -m cp -r "gs://${broker_bucket}/consumer" "${brokerdir}"
 gsutil -m cp -r "gs://${broker_bucket}/schema_maps" "${brokerdir}"
 

--- a/schema_maps/README.md
+++ b/schema_maps/README.md
@@ -1,0 +1,3 @@
+# Schema Maps
+
+The files in this directory contain mappings between the schema of an individual survey and the standardized schema used by the broker internally.

--- a/schema_maps/elasticc.yaml
+++ b/schema_maps/elasticc.yaml
@@ -1,0 +1,20 @@
+SURVEY: elasticc
+SURVEY_SCHEMA: https://github.com/LSSTDESC/plasticc_alerts/tree/main/Examples/plasticc_schema
+SCHEMA_VERSION: v0_9
+TOPIC_SYNTAX:
+FILTER_MAP:
+objectId: [diaObject, diaObjectId]
+prvSources: prvDiaSources
+source: diaSource
+sourceId: [diaSource, diaSourceId]
+cutoutDifference: cutoutDifference
+cutoutScience: none
+cutoutTemplate: cutoutTemplate
+filter: filterName
+mag: magpsf
+magerr: sigmapsf
+magzp: magzpsci
+psFlux: psFlux
+psFluxErr: psFluxErr
+dec: decl
+ra: ra

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,1 +1,66 @@
 # Setup Broker
+
+## Deploy
+
+Note: This assumes you've already run [setup_project.sh](setup_project.sh) at least once in your project.
+
+To deploy a broker instance, cd into this directory and do:
+
+```bash
+testid="testid"  # TODO: customize
+testid="raenpreprod"
+survey="elasticc"
+teardown="False"
+
+./setup_broker.sh "${testid}" "${teardown}" "${survey}"
+```
+
+While the consumer's install script is still running*, complete the following.
+
+A keytab file is required for authentication to the Kafka server.
+It must be uploaded to the consumer manually and then moved into place.
+`cd` into a directory containing the file `pitt-reader.user.keytab`, then run:
+
+```bash
+consumerVM="${survey}-consumer-${testid}"
+keytab="pitt-reader.user.keytab"
+
+gcloud compute scp "${keytab}" "${consumerVM}:~/${keytab}"
+gcloud compute ssh "${consumerVM}" -- sudo mv "~/${keytab}" "/home/broker/consumer/${keytab}"
+```
+
+\*If the consumer shuts down before you do this, unset its startup script and then turn it back on and upload the keyfile. Be sure to reset the startup script. This can be done at anytime after you've turned the consumer back on (the point at which it checks for one).
+
+After the consumer shuts down, complete the following.
+
+The consumer install requires a larger machine size than its every-day operations will.
+Change the machine size to something smaller:
+
+```bash
+gcloud compute instances set-machine-type "${consumerVM}" --machine-type="g1-small"
+```
+
+## Test
+
+To test the consumer, unset the startup script (see instructions above), `ssh` in, manually run the part of the startup script that polls for a list of topics, and inspect the results.
+
+To test other modules, publish several test alerts into their trigger topic(s).
+Then inspect the results. (Expected results differ by module.)
+Here's an example that just publishes one message to the main `alerts` topic:
+
+```python
+from broker_utils import gcp_utils as gcp
+
+testid = "testid"  # TODO: customize
+testid = "raenpreprod"
+survey = "elasticc"
+
+# load a message for testing
+sub = f"{survey}-loop"
+msgs = gcp.pull_pubsub(sub, msg_only=False)
+msg = msgs[0].message
+
+# publish the message
+topic = f"{survey}-alerts-{testid}"
+gcp.publish_pubsub(topic, msg.data, attrs=msg.attributes)
+```

--- a/setup/deploy_cloud_fncs.sh
+++ b/setup/deploy_cloud_fncs.sh
@@ -7,15 +7,15 @@ survey="${3:-elasticc}"
 zone="${CE_ZONE:-us-central1-a}"
 
 #--- GCP resources used in this script
-store_bq_trigger_topic="${survey}-alerts"
-store_bq_CF_name="${survey}-store_in_BigQuery"
+# store_bq_trigger_topic="${survey}-alerts"
+# store_bq_CF_name="${survey}-store_in_BigQuery"
 ps_to_gcs_trigger_topic="${survey}-alerts"
 ps_to_gcs_CF_name="${survey}-upload_bytes_to_bucket"
 
 # use test resources, if requested
 if [ "${testid}" != "False" ]; then
-    store_bq_trigger_topic="${store_bq_trigger_topic}-${testid}"
-    store_bq_CF_name="${store_bq_CF_name}-${testid}"
+    # store_bq_trigger_topic="${store_bq_trigger_topic}-${testid}"
+    # store_bq_CF_name="${store_bq_CF_name}-${testid}"
     ps_to_gcs_trigger_topic="${ps_to_gcs_trigger_topic}-${testid}"
     ps_to_gcs_CF_name="${ps_to_gcs_CF_name}-${testid}"
 
@@ -24,20 +24,20 @@ fi
 if [ "${teardown}" = "True" ]; then
     # ensure that we do not teardown production resources
     if [ "${testid}" != "False" ]; then
-        gcloud functions delete "$store_bq_CF_name"
+        # gcloud functions delete "$store_bq_CF_name"
         gcloud functions delete "${ps_to_gcs_CF_name}"
     fi
 
 else # Deploy the Cloud Functions
 
-    #--- BigQuery storage cloud function
-    echo "Deploying Cloud Function: ${store_bq_CF_name}"
-    gcloud functions deploy "${store_bq_CF_name}" \
-        --entry-point "run" \
-        --source "../broker/cloud_functions/store_BigQuery" \
-        --runtime "python37" \
-        --trigger-topic "${store_bq_trigger_topic}" \
-        --set-env-vars "TESTID=${testid},SURVEY=${survey}"
+    # #--- BigQuery storage cloud function
+    # echo "Deploying Cloud Function: ${store_bq_CF_name}"
+    # gcloud functions deploy "${store_bq_CF_name}" \
+    #     --entry-point "run" \
+    #     --source "../broker/cloud_functions/store_BigQuery" \
+    #     --runtime "python37" \
+    #     --trigger-topic "${store_bq_trigger_topic}" \
+    #     --set-env-vars "TESTID=${testid},SURVEY=${survey}"
 
     #--- Pub/Sub -> Cloud Storage Avro cloud function
     echo "Deploying Cloud Function: ${ps_to_gcs_CF_name}"

--- a/setup/setup_broker.sh
+++ b/setup/setup_broker.sh
@@ -28,8 +28,8 @@ fi
 avro_bucket="${PROJECT_ID}-${survey}-alert_avros"
 avro_topic="projects/${PROJECT_ID}/topics/${survey}-alert_avros"
 broker_bucket="${PROJECT_ID}-${survey}-broker_files"
-bq_dataset="${PROJECT_ID}:${survey}_alerts"
-bq_topic="projects/${PROJECT_ID}/topics/${survey}-BigQuery"
+# bq_dataset="${PROJECT_ID}:${survey}_alerts"
+# bq_topic="projects/${PROJECT_ID}/topics/${survey}-BigQuery"
 topic_alerts="${survey}-alerts"
 # use test resources, if requested
 # (there must be a better way to do this)
@@ -37,12 +37,12 @@ if [ "$testid" != "False" ]; then
     avro_bucket="${avro_bucket}-${testid}"
     avro_topic="${avro_topic}-${testid}"
     broker_bucket="${broker_bucket}-${testid}"
-    bq_dataset="${bq_dataset}_${testid}"
-    bq_topic="${bq_topic}-${testid}"
+    # bq_dataset="${bq_dataset}_${testid}"
+    # bq_topic="${bq_topic}-${testid}"
     topic_alerts="${topic_alerts}-${testid}"
 fi
-alerts_table="alerts"
-source_table="DIASource"
+# alerts_table="alerts"
+# source_table="DIASource"
 
 
 # broker bucket
@@ -69,12 +69,12 @@ echo "Configuring VMs..."
 if [ "${teardown}" != "True" ]; then
     echo "Configuring BigQuery, GCS, Pub/Sub resources..."
     # create bigquery
-    bq mk --dataset "${bq_dataset}"
-    bq mk --table "${bq_dataset}.${alerts_table}" "templates/bq_${survey}_${alerts_table}_schema.json"
-    bq mk --table "${bq_dataset}.${source_table}" "templates/bq_${survey}_${source_table}_schema.json"
+    # bq mk --dataset "${bq_dataset}"
+    # bq mk --table "${bq_dataset}.${alerts_table}" "templates/bq_${survey}_${alerts_table}_schema.json"
+    # bq mk --table "${bq_dataset}.${source_table}" "templates/bq_${survey}_${source_table}_schema.json"
     # create pubsub
     gcloud pubsub topics create "${avro_topic}"
-    gcloud pubsub topics create "${bq_topic}"
+    # gcloud pubsub topics create "${bq_topic}"
     gcloud pubsub topics create "${topic_alerts}"
     gcloud pubsub subscriptions create "${topic_alerts}-reservoir" --topic "${topic_alerts}"
     # set iam policies for topics. this is a custom role that we created
@@ -83,7 +83,7 @@ if [ "${teardown}" != "True" ]; then
     user="allUsers"
 
     ./set_iam_policy.sh "${avro_topic}" "${roleid}" "${user}"
-    ./set_iam_policy.sh "${bq_topic}" "${roleid}" "${user}"
+    # ./set_iam_policy.sh "${bq_topic}" "${roleid}" "${user}"
     ./set_iam_policy.sh "${topic_alerts}" "${roleid}" "${user}"
 
     #--- Setup the Pub/Sub notifications on ZTF Avro storage bucket
@@ -99,9 +99,9 @@ if [ "${teardown}" != "True" ]; then
 else
     # ensure that we do not teardown production resources
     if [ "${testid}" != "False" ]; then
-        bq rm --dataset true "${bq_dataset}"
+        # bq rm --dataset true "${bq_dataset}"
         gcloud pubsub topics delete "${avro_topic}"
-        gcloud pubsub topics delete "${bq_topic}"
+        # gcloud pubsub topics delete "${bq_topic}"
         gcloud pubsub topics delete "${topic_alerts}"
         gcloud pubsub subscriptions delete "${topic_alerts}-reservoir"
     fi

--- a/setup/upload_broker_bucket.sh
+++ b/setup/upload_broker_bucket.sh
@@ -5,4 +5,5 @@ echo
 echo "Uploading broker files to GCS..."
 o="GSUtil:parallel_process_count=1" # disable multiprocessing for Macs
 gsutil -m -o "${o}" cp -r ../broker/consumer "gs://${broker_bucket}"
+gsutil -m -o "${o}" cp -r ../schema_maps "gs://${broker_bucket}"
 gsutil -m -o "${o}" cp -r ../setup "gs://${broker_bucket}"


### PR DESCRIPTION
- Remove all resources belonging to the BigQuery module from deployment. For now they are just commented out.
- Various bug fixes
- Add a kwarg that prevents the Cloud Storage module from uploading duplicate alerts.
- Add the `krb5.conf` file to the repo and code the consumer's install script to move it into place. Going forward only the keytab file will need to be uploaded manually.
- Other minor improvements like better protection of the keytab file against accidental deletion.
- Add deployment and testing instructions to `setup/README.md`.

See `setup/README.md` for deployment and testing instructions.