### PR TITLE
Assign static IP to Consumer VM

### DIFF
--- a/broker/consumer/vm_install.sh
+++ b/broker/consumer/vm_install.sh
@@ -5,6 +5,7 @@
 #--- Get metadata attributes
 baseurl="http://metadata.google.internal/computeMetadata/v1"
 H="Metadata-Flavor: Google"
+PROJECT_ID=$(curl "${baseurl}/project/project-id" -H "${H}")
 consumerVM=$(curl "${baseurl}/instance/name" -H "${H}")
 zone=$(curl "${baseurl}/instance/zone" -H "${H}")
 

--- a/broker/consumer/vm_shutdown.sh
+++ b/broker/consumer/vm_shutdown.sh
@@ -4,7 +4,8 @@
 baseurl="http://metadata.google.internal/computeMetadata/v1"
 H="Metadata-Flavor: Google"
 vm_name="$(curl "${baseurl}/instance/name" -H "${H}")"
+zone=$(curl "${baseurl}/instance/zone" -H "${H}")
 
 # Unset FORCE topics in metadata so there's no unexpected behvaior on next startup
 topics="KAFKA_TOPIC_FORCE=,PS_TOPIC_FORCE="
-gcloud compute instances add-metadata "${vm_name}" --metadata="${topics}"
+gcloud compute instances add-metadata "${vm_name}" --zone="${zone}" --metadata="${topics}"

--- a/broker/setup_broker/create_vms.sh
+++ b/broker/setup_broker/create_vms.sh
@@ -10,7 +10,7 @@ testid="${2:-test}"
 teardown="${3:-False}" # "True" tearsdown/deletes resources, else setup
 survey="${4:-ztf}"
 # name of the survey this broker instance will ingest
-zone="${CE_ZONE:-us-central1-a}" # use env variable CE_ZONE if it exists
+zone="${5:-us-central1-a}"
 
 #--- GCP resources used in this script
 consumerVM="${survey}-consumer"
@@ -50,6 +50,9 @@ else
         --metadata=google-logging-enabled=true,startup-script-url="$installscript"
 
 #--- Consumer VM
+    # create a static ip address so that it can be whitelisted by the survey
+    gcloud compute addresses create ADDRESS_NAME  \
+        --region=REGION
     # create schedule
     start_schedule='30 1 * * *'  # 1:30am UTC / 5:30pm PDT, everyday
     stop_schedule='55 13 * * *'  # 1:55pm UTC / 6:55am PDT, everyday

--- a/broker/setup_broker/create_vms.sh
+++ b/broker/setup_broker/create_vms.sh
@@ -10,7 +10,8 @@ testid="${2:-test}"
 teardown="${3:-False}" # "True" tearsdown/deletes resources, else setup
 survey="${4:-ztf}"
 # name of the survey this broker instance will ingest
-zone="${5:-us-central1-a}"
+region="${5:-us-central1}"
+zone="${6:-us-central1-a}"
 
 #--- GCP resources used in this script
 consumerVM="${survey}-consumer"
@@ -22,6 +23,7 @@ if [ "$testid" != "False" ]; then
     consumerVM="${consumerVM}-${testid}"
     nconductVM="${nconductVM}-${testid}"
 fi
+consumerIP="${consumerVM}"  # gcp resource name of the consumer's static ip address
 
 #--- Teardown resources
 if [ "$teardown" = "True" ]; then
@@ -51,8 +53,7 @@ else
 
 #--- Consumer VM
     # create a static ip address so that it can be whitelisted by the survey
-    gcloud compute addresses create ADDRESS_NAME  \
-        --region=REGION
+    gcloud compute addresses create "${consumerIP}" --region="${region}"
     # create schedule
     start_schedule='30 1 * * *'  # 1:30am UTC / 5:30pm PDT, everyday
     stop_schedule='55 13 * * *'  # 1:55pm UTC / 6:55am PDT, everyday
@@ -70,6 +71,7 @@ else
     gcloud compute instances create "$consumerVM" \
         --resource-policies="${consumerVMsched}" \
         --zone="$zone" \
+        --address="$consumerIP" \
         --machine-type="$machinetype" \
         --scopes=cloud-platform \
         --metadata="${googlelogging},${startupscript},${shutdownscript}" \

--- a/broker/setup_broker/deploy_cloud_fncs.sh
+++ b/broker/setup_broker/deploy_cloud_fncs.sh
@@ -10,7 +10,7 @@ teardown="${2:-False}"
 survey="${3:-ztf}"
 # name of the survey this broker instance will ingest
 versiontag="${4:-v3_3}"
-zone="${CE_ZONE:-us-central1-a}" # use env variable CE_ZONE if it exists
+zone="${5:-us-central1-a}"
 
 #--- GCP resources used in this script
 store_bq_trigger_topic="${survey}-alerts"

--- a/broker/setup_broker/setup_broker.sh
+++ b/broker/setup_broker/setup_broker.sh
@@ -92,7 +92,7 @@ fi
 #--- Create VM instances
 echo
 echo "Configuring VMs..."
-./create_vms.sh "$broker_bucket" "$testid" "$teardown" "$survey" "$zone"
+./create_vms.sh "$broker_bucket" "$testid" "$teardown" "$survey" "$region" "$zone"
 
 
 #--- Create the cron jobs that check the VM status

--- a/broker/setup_broker/setup_broker.sh
+++ b/broker/setup_broker/setup_broker.sh
@@ -12,6 +12,8 @@ survey="${3:-ztf}"
 schema_version="${4:-3.3}"
 versiontag=v$(echo "${schema_version}" | tr . _)  # 3.3 -> v3_3
 region="${5:-us-central1}"
+zone="${region}-a"  # just use zone "a" instead of adding another script arg
+
 PROJECT_ID=$GOOGLE_CLOUD_PROJECT # get the environment variable
 
 #--- Make the user confirm the settings
@@ -90,7 +92,7 @@ fi
 #--- Create VM instances
 echo
 echo "Configuring VMs..."
-./create_vms.sh "$broker_bucket" "$testid" "$teardown" "$survey"
+./create_vms.sh "$broker_bucket" "$testid" "$teardown" "$survey" "$zone"
 
 
 #--- Create the cron jobs that check the VM status
@@ -127,4 +129,4 @@ fi
 #--- Deploy Cloud Functions
 echo
 echo "Configuring Cloud Functions..."
-./deploy_cloud_fncs.sh "${testid}" "${teardown}" "${survey}" "${versiontag}"
+./deploy_cloud_fncs.sh "${testid}" "${teardown}" "${survey}" "${versiontag}" "${zone}"

--- a/docs/source/broker/run-a-broker-instance/setup-broker.rst
+++ b/docs/source/broker/run-a-broker-instance/setup-broker.rst
@@ -71,9 +71,10 @@ You can use the ``gcloud compute scp`` command for this:
 
     survey=ztf  # use the same survey used in broker setup
     testid=mytest  # use the same testid used in broker setup
+    zone=us-central1-a  # use the VM's zone
 
-    gcloud compute scp krb5.conf "${survey}-consumer-${testid}:/etc/krb5.conf" --zone="$CE_ZONE"
-    gcloud compute scp pitt-reader.user.keytab "${survey}-consumer-${testid}:/home/broker/consumer/pitt-reader.user.keytab" --zone="$CE_ZONE"
+    gcloud compute scp krb5.conf "${survey}-consumer-${testid}:/etc/krb5.conf" --zone="${zone}"
+    gcloud compute scp pitt-reader.user.keytab "${survey}-consumer-${testid}:/home/broker/consumer/pitt-reader.user.keytab" --zone="${zone}"
 
 --------------
 


### PR DESCRIPTION
This is being done in response to a request from ZTF for an IP address that they can whitelist, which will be necessary for an upcoming changes on their end.

Primary change:

- Assign a static IP address to the Consumer VM.

Other changes:

- Remove the `CE_ZONE` environment variable. This "zone" is closely related to the "region" that is a setup-script argument, and it's hard to enforce consistency between the two when they come from two different places.
- Two bug-fixes in the consumer's shell scripts

@wmwv FYI
@djperrefort will you review?