### PR TITLE
Bump broker-utils 0.2.46 -> 0.2.47

### DIFF
--- a/broker/broker_utils/CHANGELOG.md
+++ b/broker/broker_utils/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## \[Unreleased\]<a name="unreleased"></a>
 
+## \[0.2.47\] - 2023-06-20
+
 ### Changed
 - `broker_utils/avro_schemas` now contains the alert schemas and broker classification schema for ELAsTiCC schema version 0.9.1
 - `avro_schemas/load.py` registers ELAsTiCC schema version 0.9.1

--- a/broker/broker_utils/setup.py
+++ b/broker/broker_utils/setup.py
@@ -31,7 +31,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='pgb_broker_utils',
-    version='0.2.46',
+    version='0.2.47',
     description='Tools used by the Pitt-Google astronomical alert broker.',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Bumps broker-utils version 0.2.46 -> 0.2.47. Version 0.2.47 has been published to PyPI.