### PR TITLE
Fix bugs in vm_startup.sh

### DIFF
--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -54,7 +54,7 @@ KAFKA_TOPIC="${KAFKA_TOPIC_FORCE:-${KAFKA_TOPIC_DEFAULT}}"
 PS_TOPIC="${PS_TOPIC_FORCE:-${PS_TOPIC_DEFAULT}}"
 # set VM metadata, just for clarity and easy viewing
 gcloud compute instances add-metadata "${consumerVM}" --zone "${zone}" \
-    --metadata ^:^CURRENT_PS_TOPIC=${PS_TOPIC}:CURRENT_KAFKA_TOPIC=${KAFKA_TOPIC}
+    --metadata "^:^CURRENT_PS_TOPIC=${PS_TOPIC}:CURRENT_KAFKA_TOPIC=${KAFKA_TOPIC}"
 
 #--- Set the connector's configs (project and topics)
 fconfig="/home/broker/consumer/ps-connector.properties"

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -40,7 +40,7 @@ fi
 rm -rf "${brokerdir}"
 
 # create broker and consumer directories
-mkdir -p "${brokerdir}"
+mkdir "${brokerdir}"
 
 #--- Download fresh config files from the bucket
 gsutil -m cp -r "gs://${broker_bucket}/consumer" "${brokerdir}"

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -41,7 +41,6 @@ rm -rf "${brokerdir}"
 
 # create broker and consumer directories
 mkdir -p "${consumerdir}"
-cd "${consumerdir}" || exit
 
 #--- Download fresh config files from the bucket
 gsutil -m cp -r "gs://${broker_bucket}/consumer" "${brokerdir}"
@@ -58,13 +57,13 @@ gcloud compute instances add-metadata "${consumerVM}" --zone "${zone}" \
     --metadata ^:^CURRENT_PS_TOPIC=${PS_TOPIC}:CURRENT_KAFKA_TOPIC=${KAFKA_TOPIC}
 
 #--- Set the connector's configs (project and topics)
-fconfig="ps-connector.properties"
+fconfig="/home/broker/consumer/ps-connector.properties"
 sed -i "s/PROJECT_ID/${PROJECT_ID}/g" "${fconfig}"
 sed -i "s/PS_TOPIC/${PS_TOPIC}/g" "${fconfig}"
 sed -i "s/KAFKA_TOPIC/${KAFKA_TOPIC}/g" "${fconfig}"
 
 #--- Set the Kafka offset
-fconfig="psconnect-worker.properties"
+fconfig="/home/broker/consumer/psconnect-worker.properties"
 OFFSET_RESET_DEFAULT="latest"
 OFFSET_RESET="${OFFSET_RESET_FORCE:-${OFFSET_RESET_DEFAULT}}"
 sed -i "s/<OFFSET_RESET>/${OFFSET_RESET}/g" "${fconfig}"

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -57,13 +57,13 @@ gcloud compute instances add-metadata "${consumerVM}" --zone "${zone}" \
     --metadata "^:^CURRENT_PS_TOPIC=${PS_TOPIC}:CURRENT_KAFKA_TOPIC=${KAFKA_TOPIC}"
 
 #--- Set the connector's configs (project and topics)
-fconfig="/home/broker/consumer/ps-connector.properties"
+fconfig="${consumerdir}/ps-connector.properties"
 sed -i "s/PROJECT_ID/${PROJECT_ID}/g" "${fconfig}"
 sed -i "s/PS_TOPIC/${PS_TOPIC}/g" "${fconfig}"
 sed -i "s/KAFKA_TOPIC/${KAFKA_TOPIC}/g" "${fconfig}"
 
 #--- Set the Kafka offset
-fconfig="/home/broker/consumer/psconnect-worker.properties"
+fconfig="${consumerdir}/psconnect-worker.properties"
 OFFSET_RESET_DEFAULT="latest"
 OFFSET_RESET="${OFFSET_RESET_FORCE:-${OFFSET_RESET_DEFAULT}}"
 sed -i "s/<OFFSET_RESET>/${OFFSET_RESET}/g" "${fconfig}"

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -40,7 +40,7 @@ fi
 rm -rf "${brokerdir}"
 
 # create broker and consumer directories
-mkdir -p "${consumerdir}"
+mkdir -p "${brokerdir}"
 
 #--- Download fresh config files from the bucket
 gsutil -m cp -r "gs://${broker_bucket}/consumer" "${brokerdir}"

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -2,14 +2,11 @@
 # Configure and Start the Kafka -> Pub/Sub connector
 
 brokerdir="/home/broker"
-workingdir="${brokerdir}/consumer"
-# delete everything so we can start fresh
-rm -rf "${brokerdir}"
-cd "${workingdir}" || exit
+consumerdir="${brokerdir}/consumer"
 
 #--- Files this script will write
-fout_run="${workingdir}/run-connector.out"
-fout_topics="${workingdir}/list.topics"
+fout_run="${consumerdir}/run-connector.out"
+fout_topics="${consumerdir}/list.topics"
 
 #--- Get project and instance metadata
 # for info on working with metadata, see here
@@ -39,6 +36,13 @@ if [ "$testid" != "False" ]; then
     PS_TOPIC_DEFAULT="${PS_TOPIC_DEFAULT}-${testid}"
 fi
 
+# delete everything so we can start fresh
+rm -rf "${brokerdir}"
+
+# create broker and consumer directories
+mkdir -p "${consumerdir}"
+cd "${consumerdir}" || exit
+
 #--- Download fresh config files from the bucket
 gsutil -m cp -r "gs://${broker_bucket}/consumer" "${brokerdir}"
 gsutil -m cp -r "gs://${broker_bucket}/schema_maps" "${brokerdir}"
@@ -51,7 +55,7 @@ KAFKA_TOPIC="${KAFKA_TOPIC_FORCE:-${KAFKA_TOPIC_DEFAULT}}"
 PS_TOPIC="${PS_TOPIC_FORCE:-${PS_TOPIC_DEFAULT}}"
 # set VM metadata, just for clarity and easy viewing
 gcloud compute instances add-metadata "${consumerVM}" --zone "${zone}" \
-    --metadata "CURRENT_PS_TOPIC=${PS_TOPIC},CURRENT_KAFKA_TOPIC=${KAFKA_TOPIC}"
+    --metadata ^:^CURRENT_PS_TOPIC=${PS_TOPIC}:CURRENT_KAFKA_TOPIC=${KAFKA_TOPIC}
 
 #--- Set the connector's configs (project and topics)
 fconfig="ps-connector.properties"
@@ -95,6 +99,6 @@ done
 
 #--- Start the Kafka -> Pub/Sub connector, save stdout and stderr to file
 /bin/connect-standalone \
-    "${workingdir}/psconnect-worker.properties" \
-    "${workingdir}/ps-connector.properties" \
+    "${consumerdir}/psconnect-worker.properties" \
+    "${consumerdir}/ps-connector.properties" \
     &>> "${fout_run}"


### PR DESCRIPTION
This PR addresses the two issues outlined in Issue #206:
1. The script exits early because `workingdir` doesn't exist
2. The syntax for setting VM instance metadata needs to be different when a key/value pair includes commas

Actions:
- [x] Rename the `workingdir` to `consumerdir` for clarity
- [x] Update the syntax for setting VM instance metadata
- [x] Move `rm -rf "${brokerdir}")` down in the script so that it happens right before the fresh files get downloaded
- [x] Re-create the directory `broker` (otherwise the fresh config files from the bucket cannot be downloaded)
- [x] Specify the full path to `fconfig` (otherwise the script is unable to set the Kafka topic & connector's configs: project and topics)

The motivation behind the last two items is discussed in Issue #206 