### PR TITLE
Fixes bug in consumer VM startup script

### DIFF
--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -87,12 +87,23 @@ do
     # which kills the while loop. no working suggestions found.
     # passing the error with `|| true`
 
+    
+    IFS=', ' read -r -a KAFKA_TOPIC_ARRAY <<< "$KAFKA_TOPIC"
+    KAFKA_TOPIC_PRESENT=()
+
     # check if our topic is in the list
-    if grep -Fq "${KAFKA_TOPIC}" "${fout_topics}"
-    then
-        alerts_flowing="true"  # start consuming
+    for topic in "${KAFKA_TOPIC_ARRAY[@]}"; 
+    do
+        if grep -Fq "${topic}" "${fout_topics}"
+        then
+            KAFKA_TOPIC_PRESENT+=("True")
+        fi
+    done
+    
+    if [ ${#KAFKA_TOPIC_PRESENT[@]} -eq ${#KAFKA_TOPIC_ARRAY[@]} ]; then
+        alerts_flowing="true"
     else
-        sleep 60s  # sleep 1 min, then try again
+        sleep 60s
     fi
 done
 

--- a/broker/consumer/vm_startup.sh
+++ b/broker/consumer/vm_startup.sh
@@ -104,7 +104,7 @@ do
 
     # set "alerts_flowing" to "true" if the length of the arrays are equal
     if [ ${#kafka_topic_present[@]} -eq ${#KAFKA_TOPIC_ARRAY[@]} ]; then
-        alerts_flowing="true"
+        alerts_flowing="true" # start consuming
     else
         sleep 60s # sleep 1 min, then try again
     fi


### PR DESCRIPTION
Related to Issue #212. 

For the ELAsTiCC2 Challenge, our consumer VM will be listening to multiple KAFKA topics simultaneously. When defining multiple topics, the variable `KAFKA_TOPIC` is initialized as a comma-separated list of topics: `KAFKA_TOPIC="topic1,topic2,etc"`. These topics appear in the file: `list.topics` in the following format.

```
topic1
topic2
etc
```

However, this creates a bug when the following code block from `vm_startup.sh` is executed.
```
if grep -Fq "${KAFKA_TOPIC}" "${fout_topics}"
    then
        alerts_flowing="true"  # start consuming
    else
        sleep 60s  # sleep 1 min, then try again
fi
```

This is because the `grep -Fq "${KAFKA_TOPIC}" "${fout_topics}"` command looks for the exact string, `topic1,topic2,etc`, in `list.topics`.

This PR updates the requirements needed to start the Kafka -> Pub/Sub connector for our consumer VM. In order to accommodate for multiple topics, we now parse through the string containing the comma-separated Kafka topics and append each topic name to an array called `KAFKA_TOPIC_ARRAY`. Using a `for` loop, we search to see whether the elements of `KAFKA_TOPIC_ARRAY` are present in `list.topics`. If a topic is present, then the value `true` is appended to separate array: `kafka_topic_present`.

If all of the topics are present in `list.topics`, then `KAFKA_TOPIC_ARRAY` and `kafka_topic_present` will have the same length. This requirement must now be satisfied in order to start the Kafka -> Pub/Sub connector.

The changes to the startup script have been successfully tested.