### PR TITLE
fix #228

### DIFF
--- a/broker/cloud_functions/lite/main.py
+++ b/broker/cloud_functions/lite/main.py
@@ -50,7 +50,7 @@ def semantic_compression(alert_dict, schema_map) -> dict:
         "filter": source[schema_map["filter"]],
     }
 
-    access_prev = alert_dict[schema_map["prvSources"]]
+    access_prev = alert_dict.get(schema_map["prvSources"], {})
 
     prev_sources = []
 


### PR DESCRIPTION
Fixes #228 

Fallback to an empty dictionary instead of `None` when the alert contains no previous detections.