### PR TITLE
Update setup_broker.sh in Rubin directory

### DIFF
--- a/broker/setup_broker/rubin/setup_broker.sh
+++ b/broker/setup_broker/rubin/setup_broker.sh
@@ -88,4 +88,4 @@ fi
 #--- Create VM instances
 echo
 echo "Configuring VMs..."
-./create_vms.sh "${broker_bucket}" "${testid}" "${teardown}" "${survey}" "${zone}" "${firewallrule}"
+./create_vm.sh "${broker_bucket}" "${testid}" "${teardown}" "${survey}" "${zone}" "${firewallrule}"


### PR DESCRIPTION
This PR corrects a typo in `Pitt-Google-Broker/broker/setup_broker/rubin/setup_broker.sh` that prevents the execution of the `create_vm.sh` script.