### PR TITLE
Update Rubin ps-connector.properties file

### DIFF
--- a/broker/consumer/rubin/ps-connector.properties
+++ b/broker/consumer/rubin/ps-connector.properties
@@ -12,7 +12,7 @@ tasks.max=1
 # set kafka the topic
 topics=KAFKA_TOPIC
 # set the Pub/Sub configs
-cps.topic=PUBSUB_TOPIC
+cps.topic=PS_TOPIC
 cps.project=PROJECT_ID
 # include Kafka topic, partition, offset, timestamp as msg attributes
 metadata.publish=true


### PR DESCRIPTION
`sed -i "s/PS_TOPIC/${PS_TOPIC}/g" ${fconfig}`

Line 71 in the VM's startup script, displayed above, updates the value `PS_TOPIC` in the ps-connector.properties file with the appropriate PubSub topic name. Due to a typo in the ps-connector.properties file, the startup script was unable to update the `PS_TOPIC` value. This PR fixes the typo.

Changes have been tested. No additional bugs detected