### PR TITLE
Update main.py for ps_to_gcs Cloud Function

### DIFF
--- a/broker/cloud_functions/ps_to_gcs/main.py
+++ b/broker/cloud_functions/ps_to_gcs/main.py
@@ -61,8 +61,8 @@ class TempAlertFile(SpooledTemporaryFile):
 
     def rollover(self) -> None:
         """Move contents of the spooled file from memory onto disk"""
-
-        logger.log_text(f'Alert size exceeded max memory size: {self._max_size}')
+        msg = f'Alert size exceeded max memory size: {self._max_size}'
+        logger.log_text(msg, severity="WARNING")
         super().rollover()
 
     @property

--- a/broker/cloud_functions/ps_to_gcs/main.py
+++ b/broker/cloud_functions/ps_to_gcs/main.py
@@ -62,7 +62,7 @@ class TempAlertFile(SpooledTemporaryFile):
     def rollover(self) -> None:
         """Move contents of the spooled file from memory onto disk"""
 
-        log.warning(f'Alert size exceeded max memory size: {self._max_size}')
+        logger.log_text(f'Alert size exceeded max memory size: {self._max_size}')
         super().rollover()
 
     @property


### PR DESCRIPTION
Addresses the [NameError](https://console.cloud.google.com/errors/detail/COGe3u-i_YeciAE;service=ztf-upload_bytes_to_bucket;time=P1D?version=&project=ardent-cycling-243415) seen in the `ztf-upload_bytes_to_bucket` cloud function: `name 'log' is not defined`.

Additionally, updates the way log entries are written by using `logger.log_text(text)` as seen in [Google's client library documentation](https://cloud.google.com/logging/docs/reference/libraries#use). If not updated, this produces an AttributeError: `'Logger' object has no attribute 'warning'`

Changes have been tested.