### PR TITLE
Bug fix lite module: Fall back to empty list if no previous sources

### DIFF
--- a/broker/cloud_functions/ztf/lite/deploy.sh
+++ b/broker/cloud_functions/ztf/lite/deploy.sh
@@ -11,6 +11,12 @@ survey="${3:-ztf}"
 # name of the survey this broker instance will ingest
 versiontag="${4:-v4_02}"
 
+# The deployed module will rely on this env var.
+if [ -z "${GOOGLE_CLOUD_PROJECT}" ]; then
+    echo "Error: GOOGLE_CLOUD_PROJECT environment variable is not set."
+    exit 1
+fi
+
 #--- GCP resources used in this script
 lite_trigger_topic="${survey}-alerts"
 lite_CF_name="${survey}-lite"

--- a/broker/cloud_functions/ztf/lite/deploy.sh
+++ b/broker/cloud_functions/ztf/lite/deploy.sh
@@ -34,7 +34,7 @@ if [ "${teardown}" = "True" ]; then
     fi
 
 else # Deploy the Cloud Functions
-#--- alerts-lite cloud function
+    #--- alerts-lite cloud function
     echo "Deploying Cloud Function: ${lite_CF_name}"
     lite_entry_point="run"
 

--- a/broker/cloud_functions/ztf/lite/main.py
+++ b/broker/cloud_functions/ztf/lite/main.py
@@ -50,7 +50,7 @@ def semantic_compression(alert_dict, schema_map) -> dict:
         "filter": source[schema_map["filter"]],
     }
 
-    access_prev = alert_dict.get(schema_map["prvSources"], {})
+    access_prev = alert_dict[schema_map["prvSources"]] or []
 
     prev_sources = []
 

--- a/broker/cloud_functions/ztf/lite/main.py
+++ b/broker/cloud_functions/ztf/lite/main.py
@@ -22,6 +22,9 @@ ps_topic = f"{SURVEY}-lite"
 if TESTID != "False":  # attach the testid to the names
     ps_topic = f"{ps_topic}-{TESTID}"
 
+# Load here to avoid hitting the broker_files bucket for every alert.
+SCHEMA_MAP = schema_maps.load_schema_map(SURVEY, TESTID)
+
 
 def semantic_compression(alert_dict, schema_map) -> dict:
     """Construct and return the `alert_lite` dictionary."""
@@ -122,7 +125,7 @@ def run(msg: dict, context):
                 `event_type`: for example: "google.pubsub.topic.publish".
                 `resource`: the resource that emitted the event.
     """
-    schema_map = schema_maps.load_schema_map(SURVEY, TESTID)
+    schema_map = SCHEMA_MAP
 
     alert_dict = data_utils.open_alert(msg["data"], drop_cutouts=True, schema_map=schema_map)
 


### PR DESCRIPTION
Fixes #228 

cloud_functions/ztf/lite:

- If no previous sources, fall back to an empty list.
- Load the schema_map once, not for every alert.
- Exit deploy.sh early if required environment variable is not set.