### PR TITLE
LVK Consumer: Pass Kafka metadata to Pub/Sub attributes

### DIFF
--- a/broker/consumer/lvk/ps-connector.properties
+++ b/broker/consumer/lvk/ps-connector.properties
@@ -30,3 +30,5 @@ topics=KAFKA_TOPIC
 # Set the Pub/Sub configs
 cps.project=PROJECT_ID
 cps.topic=PS_TOPIC
+# include Kafka topic, partition, offset, timestamp as msg attributes
+metadata.publish=true


### PR DESCRIPTION
Our LVK consumer configuration is missing the setting that passes Kafka metadata like the topic, partition, offset, and timestamp through to the Pub/Sub message as metadata attributes. This PR adds the setting.