### PR TITLE
Bump versions for Dependabot

### DIFF
--- a/broker/night_conductor/requirements.txt
+++ b/broker/night_conductor/requirements.txt
@@ -1,6 +1,8 @@
 apache-beam[gcp]==2.25.0
 argparse
-astropy==3.2.1
+# Astropy version patched for Dependabot. Original version left as comment for provenance.
+# astropy==3.2.1
+astropy>=5.3.3
 fastavro==0.22.3
 # apache-beam 2.25.0 requires pyarrow<0.18.0,>=0.15.1
 # but google-cloud-bigquery>=2.10.0 requires pyarrow>=3

--- a/docs/source/working-notes/troyraen/AllWISE/cloud_run/requirements.txt
+++ b/docs/source/working-notes/troyraen/AllWISE/cloud_run/requirements.txt
@@ -1,3 +1,6 @@
-Flask==2.0.1
-gunicorn==20.1.0
+# Versions patched for dependabot. Original versions left as comments for provenance.
+# Flask==2.0.1
+Flask
+# gunicorn==20.1.0
+gunicorn>=22.0.0
 pgb-broker-utils

--- a/docs/source/working-notes/troyraen/AllWISE/cloud_run/requirements.txt
+++ b/docs/source/working-notes/troyraen/AllWISE/cloud_run/requirements.txt
@@ -1,6 +1,6 @@
 # Versions patched for dependabot. Original versions left as comments for provenance.
 # Flask==2.0.1
-Flask
+Flask>=2.2.5
 # gunicorn==20.1.0
 gunicorn>=22.0.0
 pgb-broker-utils


### PR DESCRIPTION
- Bump gunicorn version for Dependabot alert 22 https://github.com/mwvgroup/Pitt-Google-Broker/security/dependabot/22
- Bump astropy version for dependabot/18 https://github.com/mwvgroup/Pitt-Google-Broker/security/dependabot/18
- Bump flask version for dependabot/8 https://github.com/mwvgroup/Pitt-Google-Broker/security/dependabot/8

Neither file touched here is expected to be deployed again.