### PR TITLE
Create `lite` module for LSST

### DIFF
--- a/broker/cloud_run/lsst/lite/Dockerfile
+++ b/broker/cloud_run/lsst/lite/Dockerfile
@@ -1,0 +1,21 @@
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.12-slim
+
+# Allow statements and log messages to immediately appear in the Knative logs
+ENV PYTHONUNBUFFERED True
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/broker/cloud_run/lsst/lite/cloudbuild.yaml
+++ b/broker/cloud_run/lsst/lite/cloudbuild.yaml
@@ -1,0 +1,29 @@
+# https://cloud.google.com/build/docs/deploying-builds/deploy-cloud-run
+# containerize the module and deploy it to Cloud Run
+steps:
+# Build the image
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_MODULE_IMAGE_NAME}', '.']
+# Push the image to Artifact Registry
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['push', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_MODULE_IMAGE_NAME}']
+# Deploy image to Cloud Run
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  entrypoint: gcloud
+  args: ['run', 'deploy', '${_MODULE_NAME}', '--image', '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_MODULE_IMAGE_NAME}', '--region', '${_REGION}', '--set-env-vars', '${_ENV_VARS}']
+images:
+- '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPOSITORY}/${_MODULE_IMAGE_NAME}'
+substitutions:
+    _SURVEY: 'lsst'
+    _TESTID: 'testid'
+    _MODULE_NAME: '${_SURVEY}-lite-${_TESTID}'
+    _MODULE_IMAGE_NAME: 'gcr.io/${PROJECT_ID}/${_REPOSITORY}/${_MODULE_NAME}'
+    _REPOSITORY: 'cloud-run-services'
+    # cloud functions automatically sets the projectid env var using the name "GCP_PROJECT"
+    # use the same name here for consistency
+    # [TODO] PROJECT_ID is set in setup.sh. this is confusing and we should revisit the decision.
+    # i (Raen) think i didn't make it a substitution because i didn't want to set a default for it.
+    _ENV_VARS: 'GCP_PROJECT=${PROJECT_ID},SURVEY=${_SURVEY},TESTID=${_TESTID}'
+    _REGION: 'us-central1'
+options:
+    dynamic_substitutions: true

--- a/broker/cloud_run/lsst/lite/deploy.sh
+++ b/broker/cloud_run/lsst/lite/deploy.sh
@@ -1,0 +1,67 @@
+#! /bin/bash
+# Deploys or deletes broker Cloud Functions
+# This script will not delete Cloud Functions that are in production
+
+# "False" uses production resources
+# any other string will be appended to the names of all resources
+testid="${1:-test}"
+# "True" tearsdown/deletes resources, else setup
+teardown="${2:-False}"
+# name of the survey this broker instance will ingest
+survey="${3:-lsst}"
+region="${4:-us-central1}"
+PROJECT_ID=$GOOGLE_CLOUD_PROJECT # get the environment variable
+
+MODULE_NAME="lite"  # lower case required by cloud run
+ROUTE_RUN="/"  # url route that will trigger main.run()
+
+# function used to define GCP resources; appends testid if needed
+define_GCP_resources() {
+    local base_name="$1"
+    local testid_suffix=""
+
+    if [ "$testid" != "False" ]; then
+        testid_suffix="-${testid}"
+    fi
+
+    echo "${base_name}${testid_suffix}"
+}
+
+#--- GCP resources used in this script
+artifact_registry_repo=$(define_GCP_resources "${survey}-cloud-run-services")
+cr_module_name=$(define_GCP_resources "${survey}-${MODULE_NAME}")  # lower case required by cloud run
+ps_input_subscrip=$(define_GCP_resources "${survey}-alerts") # pub/sub subscription used to trigger cloud run module
+ps_output_topic=$(define_GCP_resources "${survey}-lite")
+runinvoker_svcact="cloud-run-invoker@${PROJECT_ID}.iam.gserviceaccount.com"
+trigger_topic=$(define_GCP_resources "${survey}-alerts")
+
+
+if [ "${teardown}" = "True" ]; then
+    # ensure that we do not teardown production resources
+    if [ "${testid}" != "False" ]; then
+        gcloud pubsub topics delete "${ps_output_topic}"
+        gcloud run services delete "${cr_module_name}" --region "${region}"
+    fi
+
+else # Deploy the Cloud Run service
+
+#--- Deploy Cloud Run
+    gcloud pubsub topics create "${ps_output_topic}"
+
+    echo "Creating container image and deploying to Cloud Run..."
+    moduledir="."  # assumes deploying what's in our current directory
+    config="${moduledir}/cloudbuild.yaml"
+    url=$(gcloud builds submit --config="${config}" \
+        --substitutions="_SURVEY=${survey},_TESTID=${testid},_MODULE_NAME=${cr_module_name},_REPOSITORY=${artifact_registry_repo}" \
+        "${moduledir}" | sed -n 's/^Step #2: Service URL: \(.*\)$/\1/p')
+
+    echo "Creating trigger subscription for Cloud Run..."
+    # WARNING:  This is set to retry failed deliveries. If there is a bug in main.py this will
+    # retry indefinitely, until the message is delete manually.
+    gcloud pubsub subscriptions create "${ps_input_subscrip}" \
+        --topic "${trigger_topic}" \
+        --topic-project "${PROJECT_ID}" \
+        --ack-deadline=600 \
+        --push-endpoint="${url}${ROUTE_RUN}" \
+        --push-auth-service-account="${runinvoker_svcact}"
+fi

--- a/broker/cloud_run/lsst/lite/deploy.sh
+++ b/broker/cloud_run/lsst/lite/deploy.sh
@@ -40,6 +40,7 @@ if [ "${teardown}" = "True" ]; then
     # ensure that we do not teardown production resources
     if [ "${testid}" != "False" ]; then
         gcloud pubsub topics delete "${ps_output_topic}"
+        gcloud pubsub subscriptions delete "${ps_input_subscrip}"
         gcloud run services delete "${cr_module_name}" --region "${region}"
     fi
 

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -7,6 +7,7 @@ import os
 import flask
 import pittgoogle
 from google.cloud import logging
+from typing import Optional
 
 # [FIXME] Make this helpful or else delete it.
 # Connect the python logger to the google cloud logger.
@@ -105,7 +106,7 @@ def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
 
 def _create_prv_sources_dict(
     source_history: list[dict], field_names: list[str]
-) -> list[dict] | None:
+) -> Optional[list[dict]]:
     """Create a list of prv_sources dictionaries."""
 
     if source_history is None:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -5,6 +5,7 @@
 
 import os
 from typing import Optional
+
 import flask
 import pittgoogle
 from google.cloud import logging

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -4,10 +4,10 @@
 """This module creates a "lite" LSST alert containing a subset of fields from the original LSST alert."""
 
 import os
+from typing import Optional
 import flask
 import pittgoogle
 from google.cloud import logging
-from typing import Optional
 
 # [FIXME] Make this helpful or else delete it.
 # Connect the python logger to the google cloud logger.
@@ -107,7 +107,7 @@ def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
 def _create_prv_sources_dict(
     source_history: list[dict], field_names: list[str]
 ) -> Optional[list[dict]]:
-    """Create a list of prv_sources dictionaries."""
+    """Create a list of prv_sources dictionaries if they exist."""
 
     if source_history is None:
         return source_history

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -100,7 +100,7 @@ def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
         "dec_err",
         "flux",
         "flux_err",
-        "band",
+        "filter",
     ]
 
     return _get_survey_field_names(alert, broker_field_names)

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -4,7 +4,6 @@
 """This module creates a "lite" alert containing a subset of fields from the original alert packet."""
 
 import os
-from typing import Optional
 
 import flask
 import pittgoogle

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -118,7 +118,7 @@ def _create_fields_list(field: str) -> list[str]:
 
         return source_fields_list
 
-    elif field == "object":
+    if field == "object":
         object_fields_list = [
             "diaObjectId",
             "nearbyObj1",
@@ -140,7 +140,7 @@ def _create_fields_list(field: str) -> list[str]:
 
         return object_fields_list
 
-    elif field == "ssobject":
+    if field == "ssobject":
         ss_object_fields_list = [
             "ssObjectId",
             "firstObservationDate",
@@ -171,6 +171,9 @@ def _create_fields_list(field: str) -> list[str]:
         ]
 
         return ss_object_fields_list
+
+    else:
+        raise ValueError(f"Unrecognized field type: {field}")
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -67,14 +67,14 @@ def run():
 
 
 def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
-    """Create a "lite" alert containing a subset of the fields of the original alert packet."""
+    """Creates a "lite" alert containing a subset of the fields of the original alert packet."""
 
-    # define the fields that will be present in the lite alert
-    source_fields_list = _create_fields_list(field="source")
-    object_fields_list = _create_fields_list(field="object")
-    ss_object_fields_list = _create_fields_list(field="ssobject")
+    # create a list of field names that will be included in a lite dictionary
+    source_fields_list = _get_fields(field_name=alert.get_key("source"))
+    object_fields_list = _get_fields(field_name=alert.get_key("object"))
+    ss_object_fields_list = _get_fields(field_name=alert.get_key("ss_object"))
 
-    # create lite versions of fields in the original alert packet
+    # create lite dictionaries for each of the fields that will be included in the lite alert
     object_lite_dict = _create_lite_dict(
         alert.dict.get(alert.get_key("object")), object_fields_list
     )
@@ -87,9 +87,9 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     ssobject_lite_dict = _create_lite_dict(
         alert.dict.get(alert.get_key("ss_object")), ss_object_fields_list
     )
-    # create lite dictionary
+    # create the lite dictionary for the outgoing alert
     alert_lite_dict = {
-        alert.get_key("alertid"): alert.alertid,
+        alert.get_key("alertid"): alert.get("alertid"),
         alert.get_key("source"): source_lite_dict,
         alert.get_key("prv_sources"): prev_sources_lite_dict,
         "prvDiaForcedSources": alert.dict.get("prvDiaForcedSources"),
@@ -101,9 +101,9 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name=f"{SURVEY}")
 
 
-def _create_fields_list(field: str) -> list[str]:
-    """Creates a list of survey-specific field names that will be included in the lite dictionary."""
-    if field == "source":
+def _get_fields(field_name: str) -> list[str]:
+    """Returns a list of survey-specific field names that will be included in a lite dictionary."""
+    if field_name == "diaSource":
         source_fields_list = [
             "diaSourceId",
             "midpointMjdTai",
@@ -118,7 +118,7 @@ def _create_fields_list(field: str) -> list[str]:
 
         return source_fields_list
 
-    if field == "object":
+    if field_name == "diaObject":
         object_fields_list = [
             "diaObjectId",
             "nearbyObj1",
@@ -140,7 +140,7 @@ def _create_fields_list(field: str) -> list[str]:
 
         return object_fields_list
 
-    if field == "ssobject":
+    if field_name == "ssObject":
         ss_object_fields_list = [
             "ssObjectId",
             "firstObservationDate",
@@ -172,7 +172,9 @@ def _create_fields_list(field: str) -> list[str]:
 
         return ss_object_fields_list
 
-    raise ValueError(f"Unrecognized field type: {field}")
+    raise ValueError(
+        f"Unrecognized field type: {field_name}. Only 'diaSource', 'diaObject', and 'ssObject' are supported."
+    )
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -69,28 +69,12 @@ def run():
 def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     """Create a "lite" alert containing a subset of the fields of the original alert packet."""
 
-    object_fields_list = [
-        "diaObjectId",
-        "nearbyObj1",
-        "nearbyObj2",
-        "nearbyObj3",
-        "nearbyObj1Dist",
-        "nearbyObj2Dist",
-        "nearbyObj3Dist",
-        "nearbyObj1LnP",
-        "nearbyObj2LnP",
-        "nearbyObj3LnP",
-        "u_psfFluxErrMean",
-        "g_psfFluxErrMean",
-        "r_psfFluxErrMean",
-        "i_psfFluxErrMean",
-        "z_psfFluxErrMean",
-        "y_psfFluxErrMean",
-    ]
+    # define the fields that will be present in the lite alert
+    source_fields_list = _create_fields_list(field="source")
+    object_fields_list = _create_fields_list(field="object")
+    ss_object_fields_list = _create_fields_list(field="ssobject")
 
-    source_fields_list = _create_source_fields_list(alert)
-
-    # create dictionaries
+    # create lite versions of fields in the original alert packet
     object_lite_dict = _create_lite_dict(
         alert.dict.get(alert.get_key("object")), object_fields_list
     )
@@ -100,48 +84,99 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     source_lite_dict = _create_lite_dict(
         alert.dict.get(alert.get_key("source")), source_fields_list
     )
+    ssobject_lite_dict = _create_lite_dict(
+        alert.dict.get(alert.get_key("ss_object")), ss_object_fields_list
+    )
+    # create lite dictionary
     alert_lite_dict = {
         alert.get_key("alertid"): alert.alertid,
         alert.get_key("source"): source_lite_dict,
         alert.get_key("prv_sources"): prev_sources_lite_dict,
+        "prvDiaForcedSources": alert.dict.get("prvDiaForcedSources"),
+        "prvDiaNondetectionLimits": alert.dict.get("prvDiaNondetectionLimits"),
         alert.get_key("object"): object_lite_dict,
+        alert.get_key("ss_object"): ssobject_lite_dict,
     }
 
     return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name=f"{SURVEY}")
 
 
-def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
-    """Creates a list of survey-specific field names to be included in the lite alert for the source dictionary."""
-    broker_field_names = [
-        "sourceid",
-        "mjd",
-        "ra",
-        "ra_err",
-        "dec",
-        "dec_err",
-        "flux",
-        "flux_err",
-        "filter",
-    ]
+def _create_fields_list(field: str) -> list[str]:
+    """Creates a list of survey-specific field names that will be included in the lite dictionary."""
+    if field == "source":
+        source_fields_list = [
+            "diaSourceId",
+            "midpointMjdTai",
+            "ra",
+            "raErr",
+            "dec",
+            "decErr",
+            "psfFlux",
+            "psfFluxErr",
+            "band",
+        ]
 
-    return _get_survey_field_names(alert, broker_field_names)
+        return source_fields_list
 
+    elif field == "object":
+        object_fields_list = [
+            "diaObjectId",
+            "nearbyObj1",
+            "nearbyObj2",
+            "nearbyObj3",
+            "nearbyObj1Dist",
+            "nearbyObj2Dist",
+            "nearbyObj3Dist",
+            "nearbyObj1LnP",
+            "nearbyObj2LnP",
+            "nearbyObj3LnP",
+            "u_psfFluxErrMean",
+            "g_psfFluxErrMean",
+            "r_psfFluxErrMean",
+            "i_psfFluxErrMean",
+            "z_psfFluxErrMean",
+            "y_psfFluxErrMean",
+        ]
 
-def _get_survey_field_names(alert: pittgoogle.Alert, broker_field_names: list) -> list[str]:
-    """Returns a list of survey-specific field names to be included in the lite dictionary."""
-    _survey_field_names = [alert.get_key(field) for field in broker_field_names]
+        return object_fields_list
 
-    # fields may be lists, extract the second element
-    survey_field_names = [
-        _survey_field_name[1] if isinstance(_survey_field_name, list) else _survey_field_name
-        for _survey_field_name in _survey_field_names
-    ]
+    elif field == "ssobject":
+        ss_object_fields_list = [
+            "ssObjectId",
+            "firstObservationDate",
+            "arc",
+            "numObs",
+            "MOID",
+            "MOIDEclipticLongitude",
+            "MOIDDeltaV",
+            "u_H",
+            "u_HErr",
+            "u_Chi2",
+            "g_H",
+            "g_HErr",
+            "g_Chi2",
+            "r_H",
+            "r_HErr",
+            "r_Chi2",
+            "i_H",
+            "i_HErr",
+            "i_Chi2",
+            "z_H",
+            "z_HErr",
+            "z_Chi2",
+            "y_H",
+            "y_HErr",
+            "y_Chi2",
+            "medianExtendedness",
+        ]
 
-    return survey_field_names
+        return ss_object_fields_list
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
     """Returns a lite dictionary containing fields specified in field_names."""
+    if alert_dict is None:
+        return alert_dict
     return {k: v for k, v in alert_dict.items() if k in field_names}
 
 

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -69,24 +69,45 @@ def run():
 def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     """Create a "lite" alert containing a subset of the fields of the original alert packet."""
 
+    object_fields_list = [
+        "diaObjectId",
+        "nearbyObj1",
+        "nearbyObj2",
+        "nearbyObj3",
+        "nearbyObj1Dist",
+        "nearbyObj2Dist",
+        "nearbyObj3Dist",
+        "nearbyObj1LnP",
+        "nearbyObj2LnP",
+        "nearbyObj3LnP",
+        "u_psfFluxErrMean",
+        "g_psfFluxErrMean",
+        "r_psfFluxErrMean",
+        "i_psfFluxErrMean",
+        "z_psfFluxErrMean",
+        "y_psfFluxErrMean",
+    ]
+
+    source_fields_list = _create_source_fields_list(alert)
+
     # create dictionaries
     object_lite_dict = _create_lite_dict(
-        alert.dict.get(alert.get_key("object")), _create_object_fields_list(alert)
+        alert.dict.get(alert.get_key("object")), object_fields_list
     )
-    prev_sources_lite_dict = _create_prv_sources_dict(
-        alert.dict.get(alert.get_key("prv_sources")), _create_source_fields_list(alert)
+    prev_sources_lite_dict = _create_prv_sources_lite_dict(
+        alert.dict.get(alert.get_key("prv_sources")), source_fields_list
     )
     source_lite_dict = _create_lite_dict(
-        alert.dict.get(alert.get_key("source")), _create_source_fields_list(alert)
+        alert.dict.get(alert.get_key("source")), source_fields_list
     )
     alert_lite_dict = {
         alert.get_key("alertid"): alert.alertid,
-        alert.get_key("source") + "-lite": source_lite_dict,
-        alert.get_key("prv_sources") + "-lite": prev_sources_lite_dict,
-        alert.get_key("object") + "-lite": object_lite_dict,
+        alert.get_key("source"): source_lite_dict,
+        alert.get_key("prv_sources"): prev_sources_lite_dict,
+        alert.get_key("object"): object_lite_dict,
     }
 
-    return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name=f"{SURVEY}.lite")
+    return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name=f"{SURVEY}")
 
 
 def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
@@ -106,30 +127,6 @@ def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
     return _get_survey_field_names(alert, broker_field_names)
 
 
-def _create_object_fields_list(alert: pittgoogle.Alert) -> list[str]:
-    """Creates a list of survey-specific field names to be included in the lite alert for the object dictionary."""
-    broker_field_names = [
-        "objectid",
-        "nearby_object1",
-        "nearby_object2",
-        "nearby_object3",
-        "nearby_object1_distance",
-        "nearby_object2_distance",
-        "nearby_object3_distance",
-        "prob_is_object1",
-        "prob_is_object2",
-        "prob_is_object3",
-        "u_flux_err_mean",
-        "g_flux_err_mean",
-        "r_flux_err_mean",
-        "i_flux_err_mean",
-        "z_flux_err_mean",
-        "y_flux_err_mean",
-    ]
-
-    return _get_survey_field_names(alert, broker_field_names)
-
-
 def _get_survey_field_names(alert: pittgoogle.Alert, broker_field_names: list) -> list[str]:
     """Returns a list of survey-specific field names to be included in the lite dictionary."""
     _survey_field_names = [alert.get_key(field) for field in broker_field_names]
@@ -144,27 +141,21 @@ def _get_survey_field_names(alert: pittgoogle.Alert, broker_field_names: list) -
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
-    return _drop_fields(alert_dict, field_names)
+    """Returns a lite dictionary containing fields specified in field_names."""
+    return {k: v for k, v in alert_dict.items() if k in field_names}
 
 
-def _create_prv_sources_dict(
+def _create_prv_sources_lite_dict(
     source_history: list[dict], field_names: list[str]
 ) -> Optional[list[dict]]:
-    """Create a list of prv_sources dictionaries if they exist."""
+    """Create a list of prv_sources lite dictionaries if prv_sources exist."""
 
     if source_history is None:
         return source_history
 
     prev_sources = []
     for prv_s in source_history:
-        lite_source_dict = _drop_fields(prv_s, field_names)
+        lite_source_dict = _create_lite_dict(prv_s, field_names)
         prev_sources.append(lite_source_dict)
 
     return prev_sources
-
-
-def _drop_fields(alert_dict: dict, field_names: list[str]) -> dict:
-    """Drop fields from the alert dictionary that are not present in 'field_names'."""
-    lite_dict = {k: v for k, v in alert_dict.items() if k in field_names}
-
-    return lite_dict

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -185,8 +185,8 @@ def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
 
 
 def _create_prv_sources_lite_dict(
-    source_history: list[dict], field_names: list[str]
-) -> Optional[list[dict]]:
+    source_history: list[dict] | None, field_names: list[str]
+) -> list[dict] | None:
     """Create a list of prv_sources lite dictionaries if prv_sources exist."""
 
     if source_history is None:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-"""This module creates a "lite" LSST alert containing a subset of fields from the original LSST alert."""
+"""This module creates a "lite" alert containing a subset of fields from the original alert packet."""
 
 import os
 from typing import Optional
@@ -40,8 +40,8 @@ app = flask.Flask(__name__)
 
 @app.route(ROUTE_RUN, methods=["POST"])
 def run():
-    """Produces a 'lite' LSST alert stream (${survey}-lite). Messages in this stream contain a subset of fields
-    from the original LSST alert.
+    """Produces a 'lite' alert stream (${survey}-lite). Messages in this stream contain a subset of fields
+    from the original alert packet.
 
     This module is intended to be deployed as a Cloud Run service. It will operate as an HTTP endpoint
     triggered by Pub/Sub messages. This function will be called once for every message sent to this route.
@@ -57,7 +57,7 @@ def run():
     # this contains a single Pub/Sub message with the alert to be processed
     envelope = flask.request.get_json()
     try:
-        alert = pittgoogle.Alert.from_cloud_run(envelope, "lsst")
+        alert = pittgoogle.Alert.from_cloud_run(envelope, f"{SURVEY}")
     except pittgoogle.exceptions.BadRequest as exc:
         return str(exc), HTTP_400
 
@@ -67,7 +67,7 @@ def run():
 
 
 def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
-    """Create a "lite" LSST alert containing a subset of the fields of the original alert packet."""
+    """Create a "lite" alert containing a subset of the fields of the original alert packet."""
 
     # create dictionaries
     object_lite_dict = _create_lite_dict(
@@ -86,7 +86,7 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
         alert.get_key("object") + "-lite": object_lite_dict,
     }
 
-    return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name="lsst.lite")
+    return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name=f"{SURVEY}.lite")
 
 
 def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -69,19 +69,15 @@ def run():
 def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     """Create a "lite" LSST alert containing a subset of the fields of the original alert packet."""
 
-    # create lists of field names that will be kept in the lite alert
-    source_field_names = _create_source_fields_list(alert)
-    object_field_names = _create_object_fields_list(alert)
-
     # create dictionaries
-    source_lite_dict = _create_lite_dict(
-        alert.dict.get(alert.get_key("source")), source_field_names
+    object_lite_dict = _create_lite_dict(
+        alert.dict.get(alert.get_key("object")), _create_object_fields_list(alert)
     )
     prev_sources_lite_dict = _create_prv_sources_dict(
-        alert.dict.get(alert.get_key("prv_sources")), source_field_names
+        alert.dict.get(alert.get_key("prv_sources")), _create_source_fields_list(alert)
     )
-    object_lite_dict = _create_lite_dict(
-        alert.dict.get(alert.get_key("object")), object_field_names
+    source_lite_dict = _create_lite_dict(
+        alert.dict.get(alert.get_key("source")), _create_source_fields_list(alert)
     )
     alert_lite_dict = {
         alert.get_key("alertid"): alert.alertid,
@@ -94,6 +90,7 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
 
 
 def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
+    """Creates a list of survey-specific field names to be included in the lite alert for the source dictionary."""
     broker_field_names = [
         "sourceid",
         "mjd",
@@ -105,7 +102,38 @@ def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
         "flux_err",
         "band",
     ]
+
+    return _get_survey_field_names(alert, broker_field_names)
+
+
+def _create_object_fields_list(alert: pittgoogle.Alert) -> list[str]:
+    """Creates a list of survey-specific field names to be included in the lite alert for the object dictionary."""
+    broker_field_names = [
+        "objectid",
+        "nearby_object1",
+        "nearby_object2",
+        "nearby_object3",
+        "nearby_object1_distance",
+        "nearby_object2_distance",
+        "nearby_object3_distance",
+        "prob_is_object1",
+        "prob_is_object2",
+        "prob_is_object3",
+        "u_flux_err_mean",
+        "g_flux_err_mean",
+        "r_flux_err_mean",
+        "i_flux_err_mean",
+        "z_flux_err_mean",
+        "y_flux_err_mean",
+    ]
+
+    return _get_survey_field_names(alert, broker_field_names)
+
+
+def _get_survey_field_names(alert: pittgoogle.Alert, broker_field_names: list) -> list[str]:
+    """Returns a list of survey-specific field names to be included in the lite dictionary."""
     _survey_field_names = [alert.get_key(field) for field in broker_field_names]
+
     # fields may be lists, extract the second element
     survey_field_names = [
         _survey_field_name[1] if isinstance(_survey_field_name, list) else _survey_field_name
@@ -113,35 +141,6 @@ def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
     ]
 
     return survey_field_names
-
-
-def _create_object_fields_list(alert: pittgoogle.Alert) -> list[str]:
-    _object_fields_names = [
-        alert.get_key("objectid"),
-        "nearbyObj1",
-        "nearbyObj1Dist",
-        "nearbyObj1LnP",
-        "nearbyObj2",
-        "nearbyObj2Dist",
-        "nearbyObj2LnP",
-        "nearbyObj3",
-        "nearbyObj3Dist",
-        "nearbyObj3LnP",
-        "u_psfFluxErrMean",
-        "g_psfFluxErrMean",
-        "r_psfFluxErrMean",
-        "i_psfFluxErrMean",
-        "z_psfFluxErrMean",
-        "y_psfFluxErrMean",
-    ]
-
-    # fields may be lists, extract the second element
-    object_fields_names = [
-        _object_fields_name[1] if isinstance(_object_fields_name, list) else _object_fields_name
-        for _object_fields_name in _object_fields_names
-    ]
-
-    return object_fields_names
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -68,8 +68,9 @@ def run():
 def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     """Create a "lite" LSST alert containing a subset of the fields of the original alert packet."""
 
-    # 'source' field names that will be kept in the lite alert
+    # create lists of field names that will be kept in the lite alert
     source_field_names = _create_source_fields_list(alert)
+    object_field_names = _create_object_fields_list(alert)
 
     # create dictionaries
     source_lite_dict = _create_lite_dict(
@@ -78,18 +79,31 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     prev_sources_lite_dict = _create_prv_sources_dict(
         alert.dict.get(alert.get_key("prv_sources")), source_field_names
     )
-
+    object_lite_dict = _create_lite_dict(
+        alert.dict.get(alert.get_key("object")), object_field_names
+    )
     alert_lite_dict = {
         alert.get_key("alertid"): alert.alertid,
         alert.get_key("source"): source_lite_dict,
         alert.get_key("prv_sources"): prev_sources_lite_dict,
+        alert.get_key("object"): object_lite_dict,
     }
 
     return pittgoogle.Alert.from_dict(alert_lite_dict)
 
 
 def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
-    broker_field_names = ["sourceid", "mjd", "ra", "dec", "flux", "flux_err"]
+    broker_field_names = [
+        "sourceid",
+        "mjd",
+        "ra",
+        "ra_err",
+        "dec",
+        "dec_err",
+        "flux",
+        "flux_err",
+        "band",
+    ]
     _survey_field_names = [alert.get_key(field) for field in broker_field_names]
     # fields may be lists, extract the second element
     survey_field_names = [
@@ -98,6 +112,35 @@ def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
     ]
 
     return survey_field_names
+
+
+def _create_object_fields_list(alert: pittgoogle.Alert) -> list[str]:
+    _object_fields_names = [
+        alert.get_key("objectid"),
+        "nearbyObj1",
+        "nearbyObj1Dist",
+        "nearbyObj1LnP",
+        "nearbyObj2",
+        "nearbyObj2Dist",
+        "nearbyObj2LnP",
+        "nearbyObj3",
+        "nearbyObj3Dist",
+        "nearbyObj3LnP",
+        "u_psfFluxErrMean",
+        "g_psfFluxErrMean",
+        "r_psfFluxErrMean",
+        "i_psfFluxErrMean",
+        "z_psfFluxErrMean",
+        "y_psfFluxErrMean",
+    ]
+
+    # fields may be lists, extract the second element
+    object_fields_names = [
+        _object_fields_name[1] if isinstance(_object_fields_name, list) else _object_fields_name
+        for _object_fields_name in _object_fields_names
+    ]
+
+    return object_fields_names
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -97,7 +97,9 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
         alert.get_key("ss_object"): ssobject_lite_dict,
     }
 
-    return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name=f"{SURVEY}")
+    return pittgoogle.Alert.from_dict(
+        payload=alert_lite_dict, schema_name=f"{SURVEY}", attributes={**alert.attributes}
+    )
 
 
 def _get_fields(field_name: str) -> list[str]:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -92,8 +92,8 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
         alert.get_key("alertid"): alert.get("alertid"),
         alert.get_key("source"): source_lite_dict,
         alert.get_key("prv_sources"): prev_sources_lite_dict,
-        "prvDiaForcedSources": alert.dict.get("prvDiaForcedSources"),
-        "prvDiaNondetectionLimits": alert.dict.get("prvDiaNondetectionLimits"),
+        alert.get_key("prv_forced_sources"): alert.dict.get("prvDiaForcedSources"),
+        alert.get_key("prv_nondetect_limits"): alert.dict.get("prvDiaNondetectionLimits"),
         alert.get_key("object"): object_lite_dict,
         alert.get_key("ss_object"): ssobject_lite_dict,
     }

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -4,7 +4,7 @@
 """This module creates a "lite" alert containing a subset of fields from the original alert packet."""
 
 import os
-
+from typing import List, Dict, Optional
 import flask
 import pittgoogle
 from google.cloud import logging
@@ -184,8 +184,8 @@ def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
 
 
 def _create_prv_sources_lite_dict(
-    source_history: list[dict] | None, field_names: list[str]
-) -> list[dict] | None:
+    source_history: Optional[List[Dict]], field_names: List[str]
+) -> Optional[List[Dict]]:
     """Create a list of prv_sources lite dictionaries if prv_sources exist."""
 
     if source_history is None:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# -*- coding: UTF-8 -*-
+
+"""This module creates a "lite" LSST alert containing a subset of fields."""
+
+import os
+import flask
+import pittgoogle
+from google.cloud import logging
+
+# [FIXME] Make this helpful or else delete it.
+# Connect the python logger to the google cloud logger.
+# By default, this captures INFO level and above.
+# pittgoogle uses the python logger.
+# We don't currently use the python logger directly in this script, but we could.
+logging.Client().setup_logging()
+
+PROJECT_ID = os.getenv("GCP_PROJECT")
+TESTID = os.getenv("TESTID")
+SURVEY = os.getenv("SURVEY")
+
+# Variables for incoming data
+# A url route is used in setup.sh when the trigger subscription is created.
+# It is possible to define multiple routes in a single module and trigger them using different subscriptions.
+ROUTE_RUN = "/"  # HTTP route that will trigger run(). Must match deploy.sh
+
+# Variables for outgoing data
+HTTP_204 = 204  # HTTP code: Success
+HTTP_400 = 400  # HTTP code: Bad Request
+
+# GCP resources used in this module
+TOPIC_LITE = pittgoogle.Topic.from_cloud(
+    "lite", survey=SURVEY, testid=TESTID, projectid=PROJECT_ID
+)
+
+app = flask.Flask(__name__)
+
+
+@app.route(ROUTE_RUN, methods=["POST"])
+def run():
+    """Produces a 'lite' LSST alert stream (${survey}-lite). Messages in this stream contain a subset of fields
+    from the original LSST alert stream.
+
+    This module is intended to be deployed as a Cloud Run service. It will operate as an HTTP endpoint
+    triggered by Pub/Sub messages. This function will be called once for every message sent to this route.
+    It should accept the incoming HTTP request and return a response.
+
+    Returns
+    -------
+    response : tuple(str, int)
+        Tuple containing the response body (string) and HTTP status code (int). Flask will convert the
+        tuple into a proper HTTP response. Note that the response is a status message for the web server.
+    """
+    # extract the envelope from the request that triggered the endpoint
+    # this contains a single Pub/Sub message with the alert to be processed
+    envelope = flask.request.get_json()
+    try:
+        alert = pittgoogle.Alert.from_cloud_run(envelope, "lsst")
+    except pittgoogle.exceptions.BadRequest as exc:
+        return str(exc), HTTP_400
+
+    TOPIC_LITE.publish(_semantic_compression(alert), serializer="json")
+
+    return "", HTTP_204
+
+
+def _semantic_compression(alert: pittgoogle.Alert) -> pittgoogle.Alert:
+    """Construct and return the `alert_lite` dictionary."""
+    return

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 
-"""This module creates a "lite" LSST alert containing a subset of fields."""
+"""This module creates a "lite" LSST alert containing a subset of fields from the original LSST alert."""
 
 import os
 import flask
@@ -39,7 +39,7 @@ app = flask.Flask(__name__)
 @app.route(ROUTE_RUN, methods=["POST"])
 def run():
     """Produces a 'lite' LSST alert stream (${survey}-lite). Messages in this stream contain a subset of fields
-    from the original LSST alert stream.
+    from the original LSST alert.
 
     This module is intended to be deployed as a Cloud Run service. It will operate as an HTTP endpoint
     triggered by Pub/Sub messages. This function will be called once for every message sent to this route.
@@ -59,11 +59,66 @@ def run():
     except pittgoogle.exceptions.BadRequest as exc:
         return str(exc), HTTP_400
 
-    TOPIC_LITE.publish(_semantic_compression(alert), serializer="json")
+    TOPIC_LITE.publish(_create_lite_alert(alert), serializer="json")
 
     return "", HTTP_204
 
 
-def _semantic_compression(alert: pittgoogle.Alert) -> pittgoogle.Alert:
-    """Construct and return the `alert_lite` dictionary."""
-    return
+def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
+    """Create a "lite" LSST alert containing a subset of the fields of the original alert packet."""
+
+    # 'source' field names that will be kept in the lite alert
+    source_field_names = _create_source_fields_list(alert)
+
+    # create dictionaries
+    source_lite_dict = _create_lite_dict(
+        alert.dict.get(alert.get_key("source")), source_field_names
+    )
+    prev_sources_lite_dict = _create_prv_sources_dict(
+        alert.dict.get(alert.get_key("prv_sources")), source_field_names
+    )
+
+    alert_lite_dict = {
+        alert.get_key("alertid"): alert.alertid,
+        alert.get_key("source"): source_lite_dict,
+        alert.get_key("prv_sources"): prev_sources_lite_dict,
+    }
+
+    return pittgoogle.Alert.from_dict(alert_lite_dict)
+
+
+def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:
+    broker_field_names = ["sourceid", "mjd", "ra", "dec", "flux", "flux_err"]
+    _survey_field_names = [alert.get_key(field) for field in broker_field_names]
+    # fields may be lists, extract the second element
+    survey_field_names = [
+        _survey_field_name[1] if isinstance(_survey_field_name, list) else _survey_field_name
+        for _survey_field_name in _survey_field_names
+    ]
+
+    return survey_field_names
+
+
+def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
+    return _drop_fields(alert_dict, field_names)
+
+
+def _create_prv_sources_dict(source_history: list[dict], field_names: list[str]) -> list[dict]:
+    """Create a list of prv_sources dictionaries."""
+
+    if source_history is None:
+        return
+    else:
+        prev_sources = []
+        for prv_s in source_history:
+            lite_source_dict = _drop_fields(prv_s, field_names)
+            prev_sources.append(lite_source_dict)
+
+        return prev_sources
+
+
+def _drop_fields(alert_dict: dict, field_names: list[str]) -> dict:
+    """Drop fields from the alert dictionary that are not present in 'field_names'."""
+    lite_dict = {k: v for k, v in alert_dict.items() if k in field_names}
+
+    return lite_dict

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -103,18 +103,20 @@ def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:
     return _drop_fields(alert_dict, field_names)
 
 
-def _create_prv_sources_dict(source_history: list[dict], field_names: list[str]) -> list[dict]:
+def _create_prv_sources_dict(
+    source_history: list[dict], field_names: list[str]
+) -> list[dict] | None:
     """Create a list of prv_sources dictionaries."""
 
     if source_history is None:
-        return
-    else:
-        prev_sources = []
-        for prv_s in source_history:
-            lite_source_dict = _drop_fields(prv_s, field_names)
-            prev_sources.append(lite_source_dict)
+        return source_history
 
-        return prev_sources
+    prev_sources = []
+    for prv_s in source_history:
+        lite_source_dict = _drop_fields(prv_s, field_names)
+        prev_sources.append(lite_source_dict)
+
+    return prev_sources
 
 
 def _drop_fields(alert_dict: dict, field_names: list[str]) -> dict:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -172,8 +172,7 @@ def _create_fields_list(field: str) -> list[str]:
 
         return ss_object_fields_list
 
-    else:
-        raise ValueError(f"Unrecognized field type: {field}")
+    raise ValueError(f"Unrecognized field type: {field}")
 
 
 def _create_lite_dict(alert_dict: dict, field_names: list[str]) -> dict:

--- a/broker/cloud_run/lsst/lite/main.py
+++ b/broker/cloud_run/lsst/lite/main.py
@@ -85,12 +85,12 @@ def _create_lite_alert(alert: pittgoogle.Alert) -> pittgoogle.Alert:
     )
     alert_lite_dict = {
         alert.get_key("alertid"): alert.alertid,
-        alert.get_key("source"): source_lite_dict,
-        alert.get_key("prv_sources"): prev_sources_lite_dict,
-        alert.get_key("object"): object_lite_dict,
+        alert.get_key("source") + "-lite": source_lite_dict,
+        alert.get_key("prv_sources") + "-lite": prev_sources_lite_dict,
+        alert.get_key("object") + "-lite": object_lite_dict,
     }
 
-    return pittgoogle.Alert.from_dict(alert_lite_dict)
+    return pittgoogle.Alert.from_dict(payload=alert_lite_dict, schema_name="lsst.lite")
 
 
 def _create_source_fields_list(alert: pittgoogle.Alert) -> list[str]:

--- a/broker/cloud_run/lsst/lite/requirements.txt
+++ b/broker/cloud_run/lsst/lite/requirements.txt
@@ -1,0 +1,14 @@
+# As explained here
+# https://cloud.google.com/functions/docs/writing/specifying-dependencies-python
+# dependencies for a Cloud Function must be specified in a `requirements.txt`
+# file (or packaged with the function) in the same directory as `main.py`
+
+google-cloud-logging
+pittgoogle-client>=0.3.12
+
+# for Cloud Run
+# https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service
+# pinned following quickstart example. [TODO] consider un-pinning
+Flask
+gunicorn
+Werkzeug

--- a/broker/cloud_run/lsst/lite/requirements.txt
+++ b/broker/cloud_run/lsst/lite/requirements.txt
@@ -4,7 +4,7 @@
 # file (or packaged with the function) in the same directory as `main.py`
 
 google-cloud-logging
-pittgoogle-client>=0.3.12
+pittgoogle-client>=0.3.14
 
 # for Cloud Run
 # https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service

--- a/broker/setup_broker/lsst/setup_broker.sh
+++ b/broker/setup_broker/lsst/setup_broker.sh
@@ -195,4 +195,7 @@ echo "Configuring Cloud Run services..."
     #--- ps_to_storage Cloud Run service
     cd ps_to_storage
     ./deploy.sh "$testid" "$teardown" "$survey" "$region"
+
+    cd .. && cd lite
+    ./deploy.sh "$testid" "$teardown" "$survey" "$region"
 ) || exit


### PR DESCRIPTION
This PR creates a `lite` module for LSST that publishes an alert stream containing a subset of the fields from the original alert packet. Currently, the fields contained in the lite alert are:

```
{'alertId': ,
 'diaSource': {'diaSourceId': ,
  'midpointMjdTai': ,
  'ra': ,
  'raErr': ,
  'dec': ,
  'decErr': ,
  'psfFlux': ,
  'psfFluxErr': ,
  'band': },
 'prvDiaSources': [{'diaSourceId': ,
   'midpointMjdTai': ,
   'ra': ,
   'raErr': ,
   'dec': ,
   'decErr': ,
   'psfFlux': ,
   'psfFluxErr': ,
   'band': }],
'prvDiaForcedSources': [{'diaForcedSourceId': ,
   'diaObjectId': ,
   'ra': ,
   'dec': ,
   'visit': ,
   'detector': ,
   'psfFlux': ,
   'psfFluxErr': ,
   'midpointMjdTai': ,
   'band': }],
'prvDiaNondetectionLimits': [{'ccdVisitId': ,
   'midpointMjdTai': ,
   'band': ,
   'diaNoise': }],
 'diaObject': {'diaObjectId': ,
  'nearbyObj1': ,
  'nearbyObj1Dist': ,
  'nearbyObj1LnP': ,
  'nearbyObj2': ,
  'nearbyObj2Dist': ,
  'nearbyObj2LnP': ,
  'nearbyObj3': ,
  'nearbyObj3Dist': ,
  'nearbyObj3LnP': ,
  'u_psfFluxErrMean': ,
  'g_psfFluxErrMean': ,
  'r_psfFluxErrMean': ,
  'i_psfFluxErrMean': ,
  'z_psfFluxErrMean': ,
  'y_psfFluxErrMean': },
'ssObject': {'ssObjectId': ,
  'firstObservationDate': ,
  'arc': ,
  'numObs': ,
  'MOID': ,
  'MOIDEclipticLongitude': ,
  'MOIDDeltaV': ,
  'u_H': ,
  'u_HErr': ,
  'u_Chi2': ,
  'g_H': ,
  'g_HErr': ,
  'g_Chi2': ,
  'r_H': ,
  'r_HErr': ,
  'r_HChi2': ,
  'i_H': ,
  'i_HErr': ,
  'i_HChi2': ,
  'z_H': ,
  'z_HErr': ,
  'z_HChi2': ,
  'y_H': ,
  'y_HErr': ,
  'y_HChi2': ,
  'medianExtendedness': ,}
}
```