### PR TITLE
Fix bug in upsilon module

### DIFF
--- a/broker/cloud_run/lsst/classify_upsilon/main.py
+++ b/broker/cloud_run/lsst/classify_upsilon/main.py
@@ -98,7 +98,7 @@ def _classify_with_upsilon(alert_lite_df: pd.DataFrame) -> dict:
         # ---Extract data
         filter_diaSources = alert_lite_df[alert_lite_df["band"] == band]
         flux_gt_zero = filter_diaSources["psfFlux"].to_numpy() > 0
-        upsilon_dict[f"n_data_points_{band}_band"] = flux_gt_zero.sum()
+        upsilon_dict[f"n_data_points_{band}_band"] = int(flux_gt_zero.sum())
         # skip band if no detections or too few valid data points.
         # to avoid scipy's leastsq error: ("input vector length N=7 must not exceed output length M"), we require
         # that flux_gt_zero.sum() > 7

--- a/broker/cloud_run/lsst/classify_upsilon/main.py
+++ b/broker/cloud_run/lsst/classify_upsilon/main.py
@@ -98,7 +98,7 @@ def _classify_with_upsilon(alert_lite_df: pd.DataFrame) -> dict:
         # ---Extract data
         filter_diaSources = alert_lite_df[alert_lite_df["band"] == band]
         flux_gt_zero = filter_diaSources["psfFlux"].to_numpy() > 0
-        upsilon_dict[f"n_data_points_{band}_band"] = int(flux_gt_zero.sum())
+        upsilon_dict[f"n_data_points_{band}_band"] = flux_gt_zero.sum().item()
         # skip band if no detections or too few valid data points.
         # to avoid scipy's leastsq error: ("input vector length N=7 must not exceed output length M"), we require
         # that flux_gt_zero.sum() > 7

--- a/broker/cloud_run/ztf/classify_upsilon/main.py
+++ b/broker/cloud_run/ztf/classify_upsilon/main.py
@@ -99,7 +99,7 @@ def _classify_with_upsilon(alert_lite_df: pd.DataFrame) -> dict:
         # ---Extract data
         filter_candids = alert_lite_df[alert_lite_df["fid"] == fid]
         mag_gt_zero = filter_candids["magpsf"].to_numpy() > 0
-        upsilon_dict[f"n_data_points_{band_name}_band"] = mag_gt_zero.sum()
+        upsilon_dict[f"n_data_points_{band_name}_band"] = int(mag_gt_zero.sum())
         # skip band if no detections or too few valid data points.
         # to avoid scipy's leastsq error: ("input vector length N=7 must not exceed output length M"), we require
         # that mag_gt_zero.sum() > 7

--- a/broker/cloud_run/ztf/classify_upsilon/main.py
+++ b/broker/cloud_run/ztf/classify_upsilon/main.py
@@ -99,7 +99,7 @@ def _classify_with_upsilon(alert_lite_df: pd.DataFrame) -> dict:
         # ---Extract data
         filter_candids = alert_lite_df[alert_lite_df["fid"] == fid]
         mag_gt_zero = filter_candids["magpsf"].to_numpy() > 0
-        upsilon_dict[f"n_data_points_{band_name}_band"] = int(mag_gt_zero.sum())
+        upsilon_dict[f"n_data_points_{band_name}_band"] = mag_gt_zero.sum().item()
         # skip band if no detections or too few valid data points.
         # to avoid scipy's leastsq error: ("input vector length N=7 must not exceed output length M"), we require
         # that mag_gt_zero.sum() > 7


### PR DESCRIPTION
## Summary:

### Changed: 

- `cloud_run/lsst/classify_upsilon/main.py` and `cloud_run/ztf/classify_upsilon/main.py`
     - `upsilon_dict[f"n_data_points_{band}_band"] = flux_gt_zero.sum()` -> `upsilon_dict[f"n_data_points_{band}_band"] = int(flux_gt_zero.sum())`

Context:
```
filter_diaSources = alert_lite_df[alert_lite_df["band"] == band]
flux_gt_zero = filter_diaSources["psfFlux"].to_numpy() > 0
upsilon_dict[f"n_data_points_{band}_band"] = flux_gt_zero.sum()
```

Line 101 in main.py (`upsilon_dict[f"n_data_points_{band}_band"] = flux_gt_zero.sum()` in code block above) returns a NumPy scalar (`numpy.int64`). This raises a `TypeError` when the `_clean_for_json` function is called using the `publish` method (e.g., `TOPIC.publish`).


`_clean_for_json` only handles built-in Python types (int, float, etc.).