### PR TITLE
Update BigQuery table schema

### DIFF
--- a/broker/cloud_run/lsst/classify_snn/main.py
+++ b/broker/cloud_run/lsst/classify_snn/main.py
@@ -109,8 +109,6 @@ def _classify(alert_lite: pittgoogle.Alert) -> dict:
     # use `.item()` to convert numpy -> python types for later serialization
     pred_probs = pred_probs.flatten()
     snn_dict = {
-        "diaObjectId": alert_lite.dict["alert_lite"]["diaObject"]["diaObjectId"],
-        "diaSourceId": alert_lite.dict["alert_lite"]["diaSource"]["diaSourceId"],
         "prob_class0": pred_probs[0].item(),
         "prob_class1": pred_probs[1].item(),
         "predicted_class": np.argmax(pred_probs).item(),

--- a/broker/cloud_run/lsst/variability/main.py
+++ b/broker/cloud_run/lsst/variability/main.py
@@ -93,10 +93,7 @@ def _calculate_stetsonJ_statistics(alert_lite: pittgoogle.Alert) -> Dict:
     alert_lite_dict = alert_lite.dict["alert_lite"]
     alert_df = _create_dataframe(alert_lite_dict)
     bands = alert_df["band"].unique()
-    outgoing_dict = {
-        "diaObjectId": alert_lite_dict["diaObject"]["diaObjectId"],
-        "diaSourceId": alert_lite_dict["diaSource"]["diaSourceId"],
-    }
+    outgoing_dict = {}
 
     # filter diaSource(s) in alert_df based on the filter(s) used
     for band in bands:

--- a/broker/cloud_run/ztf/variability/main.py
+++ b/broker/cloud_run/ztf/variability/main.py
@@ -93,10 +93,7 @@ def _calculate_stetsonJ_statistics(alert_lite: pittgoogle.Alert) -> Dict:
     alert_lite_dict = alert_lite.dict
     alert_df = _create_dataframe(alert_lite_dict)
     bands = alert_df["filter"].map(pittgoogle.utils.ztf_fid_names()).unique()
-    outgoing_dict = {
-        "objectId": alert_lite.dict["alertIds"]["objectId"],
-        "candid": alert_lite.dict["alertIds"]["sourceId"],
-    }
+    outgoing_dict = {}
 
     # filter diaSource(s) in alert_df based on the filter(s) used
     for band in bands:

--- a/broker/setup_broker/lsst/templates/bq_lsst_SuperNNova_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_SuperNNova_schema.json
@@ -1,18 +1,34 @@
 [
     {
       "description": "Unique identifiers from the semantically compressed alert packet.",
-      "fields": [
+      "fields":[
           {
-            "description": "Unique identifier of this DiaObject.",
+            "description": "diaSource",
+            "fields": [
+                {
+                  "description": "Unique identifier of this diaSource.",
+                  "mode": "REQUIRED",
+                  "name": "diaSourceId",
+                  "type": "INTEGER"
+                }
+            ],
             "mode": "REQUIRED",
-            "name": "diaObjectId",
-            "type": "FLOAT"
+            "name": "diaSource",
+            "type": "RECORD"
           },
           {
-            "description": "Unique identifier of this DiaSource.",
+            "description": "diaObject",
+            "fields": [
+                {
+                  "description": "Unique identifier of this diaObject.",
+                  "mode": "REQUIRED",
+                  "name": "diaObjectId",
+                  "type": "INTEGER"
+                }
+            ],
             "mode": "REQUIRED",
-            "name": "diaSourceId",
-            "type": "INTEGER"
+            "name": "diaObject",
+            "type": "RECORD"
           }
       ],
       "mode": "REQUIRED",

--- a/broker/setup_broker/lsst/templates/bq_lsst_SuperNNova_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_SuperNNova_schema.json
@@ -1,19 +1,27 @@
 [
     {
-      "description": "Classification results using SuperNNova (Möller & de Boissière 2019).",
+      "description": "Unique identifiers from the semantically compressed alert packet.",
       "fields": [
           {
-            "description": "Id of the diaObject this source was associated with",
+            "description": "Unique identifier of this DiaObject.",
             "mode": "REQUIRED",
             "name": "diaObjectId",
-            "type": "INTEGER"
+            "type": "FLOAT"
           },
           {
-            "description": "Unique identifier of this DiaSource",
+            "description": "Unique identifier of this DiaSource.",
             "mode": "REQUIRED",
             "name": "diaSourceId",
             "type": "INTEGER"
-          },
+          }
+      ],
+      "mode": "REQUIRED",
+      "name": "alert_lite",
+      "type": "RECORD"
+    },
+    {
+      "description": "Classification results using SuperNNova (Möller & de Boissière 2019).",
+      "fields": [
           {
             "description": "probability object is a type Ia supernova",
             "mode": "NULLABLE",

--- a/broker/setup_broker/lsst/templates/bq_lsst_upsilon_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_upsilon_schema.json
@@ -1,18 +1,34 @@
 [
     {
       "description": "Unique identifiers from the semantically compressed alert packet.",
-      "fields": [
+      "fields":[
           {
-            "description": "Unique identifier of this DiaObject.",
+            "description": "diaSource",
+            "fields": [
+                {
+                  "description": "Unique identifier of this diaSource.",
+                  "mode": "REQUIRED",
+                  "name": "diaSourceId",
+                  "type": "INTEGER"
+                }
+            ],
             "mode": "REQUIRED",
-            "name": "diaObjectId",
-            "type": "FLOAT"
+            "name": "diaSource",
+            "type": "RECORD"
           },
           {
-            "description": "Unique identifier of this DiaSource.",
+            "description": "diaObject",
+            "fields": [
+                {
+                  "description": "Unique identifier of this diaObject.",
+                  "mode": "REQUIRED",
+                  "name": "diaObjectId",
+                  "type": "INTEGER"
+                }
+            ],
             "mode": "REQUIRED",
-            "name": "diaSourceId",
-            "type": "INTEGER"
+            "name": "diaObject",
+            "type": "RECORD"
           }
       ],
       "mode": "REQUIRED",

--- a/broker/setup_broker/lsst/templates/bq_lsst_variability_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_variability_schema.json
@@ -1,18 +1,34 @@
 [
     {
       "description": "Unique identifiers from the semantically compressed alert packet.",
-      "fields": [
+      "fields":[
           {
-            "description": "Unique identifier of this DiaObject.",
+            "description": "diaSource",
+            "fields": [
+                {
+                  "description": "Unique identifier of this diaSource.",
+                  "mode": "REQUIRED",
+                  "name": "diaSourceId",
+                  "type": "INTEGER"
+                }
+            ],
             "mode": "REQUIRED",
-            "name": "diaObjectId",
-            "type": "FLOAT"
+            "name": "diaSource",
+            "type": "RECORD"
           },
           {
-            "description": "Unique identifier of this DiaSource.",
+            "description": "diaObject",
+            "fields": [
+                {
+                  "description": "Unique identifier of this diaObject.",
+                  "mode": "REQUIRED",
+                  "name": "diaObjectId",
+                  "type": "INTEGER"
+                }
+            ],
             "mode": "REQUIRED",
-            "name": "diaSourceId",
-            "type": "INTEGER"
+            "name": "diaObject",
+            "type": "RECORD"
           }
       ],
       "mode": "REQUIRED",

--- a/broker/setup_broker/lsst/templates/bq_lsst_variability_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_variability_schema.json
@@ -1,6 +1,6 @@
 [
     {
-      "description": "Relevant variability statistics.",
+      "description": "Unique identifiers from the semantically compressed alert packet.",
       "fields": [
           {
             "description": "Unique identifier of this DiaObject.",
@@ -13,7 +13,15 @@
             "mode": "REQUIRED",
             "name": "diaSourceId",
             "type": "INTEGER"
-          },
+          }
+      ],
+      "mode": "REQUIRED",
+      "name": "alert_lite",
+      "type": "RECORD"
+    },
+    {
+      "description": "Relevant variability statistics.",
+      "fields": [
           {
             "description": "StetsonJ statistic on the DIA point source fluxes for the u band",
             "mode": "NULLABLE",

--- a/broker/setup_broker/ztf/templates/bq_ztf_value_added_variability_schema.json
+++ b/broker/setup_broker/ztf/templates/bq_ztf_value_added_variability_schema.json
@@ -1,9 +1,9 @@
 [
     {
-      "description": "Relevant variability statistics.",
+      "description": "Unique identifiers from the semantically compressed alert packet.",
       "fields": [
           {
-            "description": "object identifier or name.",
+            "description": "Object identifier or name.",
             "mode": "REQUIRED",
             "name": "objectId",
             "type": "STRING"
@@ -13,7 +13,15 @@
             "mode": "REQUIRED",
             "name": "candid",
             "type": "INTEGER"
-          },
+          }
+      ],
+      "mode": "REQUIRED",
+      "name": "alert_lite",
+      "type": "RECORD"
+    },
+    {
+      "description": "Relevant variability statistics.",
+      "fields": [
           {
             "description": "StetsonJ statistic on the DIA point source fluxes for the g band",
             "mode": "NULLABLE",


### PR DESCRIPTION
## Summary

### Changed
- `setup_broker/lsst/templates`
     - Added a new top-level field to the BigQuery table schema for: `bq_lsst_SuperNNova_schema.json` and `bq_lsst_variability_schema.json`
- `setup_broker/ztf/templates`
     - Added a new top-level field to the BigQuery table schema for `bq_value_added_ztf_variability_schema.json` 
- `cloud_run/lsst/SuperNNova/main.py`, `cloud_run/lsst/variability/main.py`, and `cloud_run/ztf/variability/main.py`:
     - Updated outgoing messages to accommodate new BigQuery table schema