### PR TITLE
Accommodate LSST schema v8_0

### DIFF
--- a/broker/setup_broker/lsst/setup_broker.sh
+++ b/broker/setup_broker/lsst/setup_broker.sh
@@ -8,8 +8,8 @@ testid="${1:-test}"
 teardown="${2:-False}"
 # name of the survey this broker instance will ingest
 survey="${3:-lsst}"
-schema_version="${4:-7.4}"
-versiontag=v$(echo "${schema_version}" | tr . _) # 7.4 -> v7_4
+schema_version="${4:-8.0}"
+versiontag=v$(echo "${schema_version}" | tr . _) # 8.0 -> v8_0
 region="${5:-us-central1}"
 zone="${region}-a"  # just use zone "a" instead of adding another script arg
 # get environment variables

--- a/broker/setup_broker/lsst/templates/bq_lsst_alerts_v8_0_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_alerts_v8_0_schema.json
@@ -6,13 +6,13 @@
     "type": "INTEGER"
   },
   {
-    "description": "Scheduler reason for the image containing this diaSource.",
+    "description": "Scheduler reason for the image containing this diaSource (RTN-097).",
     "mode": "NULLABLE",
     "name": "observation_reason",
     "type": "STRING"
   },
   {
-    "description": "Scheduler target for the image containing this diaSource.",
+    "description": "Scheduler target for the image containing this diaSource (RTN-097).",
     "mode": "NULLABLE",
     "name": "target_name",
     "type": "STRING"
@@ -60,61 +60,61 @@
         "type": "INTEGER"
       },
       {
-        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time [d].",
         "mode": "REQUIRED",
         "name": "midpointMjdTai",
         "type": "FLOAT"
       },
       {
-        "description": "Right ascension coordinate of the center of this diaSource.",
+        "description": "Right ascension coordinate of the center of this diaSource [deg].",
         "mode": "REQUIRED",
         "name": "ra",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of ra.",
+        "description": "Uncertainty of ra [deg].",
         "mode": "NULLABLE",
         "name": "raErr",
         "type": "FLOAT"
       },
       {
-        "description": "Declination coordinate of the center of this diaSource.",
+        "description": "Declination coordinate of the center of this diaSource [deg].",
         "mode": "REQUIRED",
         "name": "dec",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dec.",
+        "description": "Uncertainty of dec [deg].",
         "mode": "NULLABLE",
         "name": "decErr",
         "type": "FLOAT"
       },
       {
-        "description": "Covariance between ra and dec.",
+        "description": "Covariance between ra and dec [deg**2].",
         "mode": "NULLABLE",
         "name": "ra_dec_Cov",
         "type": "FLOAT"
       },
       {
-        "description": "x position computed by a centroiding algorithm.",
+        "description": "x position computed by a centroiding algorithm [pixel].",
         "mode": "REQUIRED",
         "name": "x",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of x.",
+        "description": "Uncertainty of x [pixel].",
         "mode": "NULLABLE",
         "name": "xErr",
         "type": "FLOAT"
       },
       {
-        "description": "y position computed by a centroiding algorithm.",
+        "description": "y position computed by a centroiding algorithm [pixel].",
         "mode": "REQUIRED",
         "name": "y",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of y.",
+        "description": "Uncertainty of y [pixel].",
         "mode": "NULLABLE",
         "name": "yErr",
         "type": "FLOAT"
@@ -126,13 +126,13 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Flux in a 12 pixel radius aperture on the difference image.",
+        "description": "Flux in a 12 pixel radius aperture on the difference image [nJy].",
         "mode": "NULLABLE",
         "name": "apFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Estimated uncertainty of apFlux.",
+        "description": "Estimated uncertainty of apFlux [nJy].",
         "mode": "NULLABLE",
         "name": "apFluxErr",
         "type": "FLOAT"
@@ -152,7 +152,7 @@
       {
         "description": "Source was detected as significantly negative.",
         "mode": "NULLABLE",
-        "name": "is_negative",
+        "name": "isNegative",
         "type": "BOOLEAN"
       },
       {
@@ -162,13 +162,13 @@
         "type": "FLOAT"
       },
       {
-        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image.",
+        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
         "mode": "NULLABLE",
         "name": "psfFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of psfFlux.",
+        "description": "Uncertainty of psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "psfFluxErr",
         "type": "FLOAT"
@@ -210,61 +210,61 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image.",
+        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
         "mode": "NULLABLE",
         "name": "trailFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailFlux.",
+        "description": "Uncertainty of trailFlux [nJy].",
         "mode": "NULLABLE",
         "name": "trailFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Right ascension coordinate of centroid for trailed source model.",
+        "description": "Right ascension coordinate of centroid for trailed source model [deg].",
         "mode": "NULLABLE",
         "name": "trailRa",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailRa.",
+        "description": "Uncertainty of trailRa [deg].",
         "mode": "NULLABLE",
         "name": "trailRaErr",
         "type": "FLOAT"
       },
       {
-        "description": "Declination coordinate of centroid for trailed source model.",
+        "description": "Declination coordinate of centroid for trailed source model [deg].",
         "mode": "NULLABLE",
         "name": "trailDec",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailDec.",
+        "description": "Uncertainty of trailDec [deg].",
         "mode": "NULLABLE",
         "name": "trailDecErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood fit of trail length.",
+        "description": "Maximum likelihood fit of trail length [arcsec].",
         "mode": "NULLABLE",
         "name": "trailLength",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailLength.",
+        "description": "Uncertainty of trailLength [nJy].",
         "mode": "NULLABLE",
         "name": "trailLengthErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing).",
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing) [deg].",
         "mode": "NULLABLE",
         "name": "trailAngle",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailAngle.",
+        "description": "Uncertainty of trailAngle [nJy].",
         "mode": "NULLABLE",
         "name": "trailAngleErr",
         "type": "FLOAT"
@@ -288,37 +288,37 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model.",
+        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleMeanFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dipoleMeanFlux.",
+        "description": "Uncertainty of dipoleMeanFlux [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleMeanFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model.",
+        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleFluxDiff",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dipoleFluxDiff.",
+        "description": "Uncertainty of dipoleFluxDiff [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleFluxDiffErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood value for the lobe separation in dipole model.",
+        "description": "Maximum likelihood value for the lobe separation in dipole model [arcsec].",
         "mode": "NULLABLE",
         "name": "dipoleLength",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe).",
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe) [deg].",
         "mode": "NULLABLE",
         "name": "dipoleAngle",
         "type": "FLOAT"
@@ -336,13 +336,13 @@
         "type": "INTEGER"
       },
       {
-        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position.",
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position [nJy].",
         "mode": "NULLABLE",
         "name": "scienceFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Estimated uncertainty of scienceFlux.",
+        "description": "Estimated uncertainty of scienceFlux [nJy].",
         "mode": "NULLABLE",
         "name": "scienceFluxErr",
         "type": "FLOAT"
@@ -366,49 +366,49 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position.",
+        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position [nJy].",
         "mode": "NULLABLE",
         "name": "templateFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of templateFlux.",
+        "description": "Uncertainty of templateFlux [nJy].",
         "mode": "NULLABLE",
         "name": "templateFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment of the source intensity.",
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixx",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment of the source intensity.",
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "iyy",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment of the source intensity.",
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixy",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment for the PSF.",
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixxPSF",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment for the PSF.",
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "iyyPSF",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment for the PSF.",
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixyPSF",
         "type": "FLOAT"
@@ -444,7 +444,7 @@
         "type": "FLOAT"
       },
       {
-        "description": "A measure of reliability, computed using information from the source and image characterization, as well as the information on the Telescope and Camera system (e.g., ghost maps, defect maps, etc.).",
+        "description": "Probability (0-1) that the diaSource is astrophysical, derived from a machine learning model.",
         "mode": "NULLABLE",
         "name": "reliability",
         "type": "FLOAT"
@@ -458,7 +458,7 @@
       {
         "description": "Source well fit by a dipole.",
         "mode": "NULLABLE",
-        "name": "is_dipole",
+        "name": "isDipole",
         "type": "BOOLEAN"
       },
       {
@@ -474,7 +474,7 @@
         "type": "TIMESTAMP"
       },
       {
-        "description": "",
+        "description": "Size of the square bounding box that fully contains the detection footprint [pixel].",
         "mode": "NULLABLE",
         "name": "bboxSize",
         "type": "INTEGER"
@@ -650,61 +650,61 @@
         "type": "INTEGER"
       },
       {
-        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time [d].",
         "mode": "REQUIRED",
         "name": "midpointMjdTai",
         "type": "FLOAT"
       },
       {
-        "description": "Right ascension coordinate of the center of this diaSource.",
+        "description": "Right ascension coordinate of the center of this diaSource [deg].",
         "mode": "REQUIRED",
         "name": "ra",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of ra.",
+        "description": "Uncertainty of ra [deg].",
         "mode": "NULLABLE",
         "name": "raErr",
         "type": "FLOAT"
       },
       {
-        "description": "Declination coordinate of the center of this diaSource.",
+        "description": "Declination coordinate of the center of this diaSource [deg].",
         "mode": "REQUIRED",
         "name": "dec",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dec.",
+        "description": "Uncertainty of dec [deg].",
         "mode": "NULLABLE",
         "name": "decErr",
         "type": "FLOAT"
       },
       {
-        "description": "Covariance between ra and dec.",
+        "description": "Covariance between ra and dec [deg**2].",
         "mode": "NULLABLE",
         "name": "ra_dec_Cov",
         "type": "FLOAT"
       },
       {
-        "description": "x position computed by a centroiding algorithm.",
+        "description": "x position computed by a centroiding algorithm [pixel].",
         "mode": "REQUIRED",
         "name": "x",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of x.",
+        "description": "Uncertainty of x [pixel].",
         "mode": "NULLABLE",
         "name": "xErr",
         "type": "FLOAT"
       },
       {
-        "description": "y position computed by a centroiding algorithm.",
+        "description": "y position computed by a centroiding algorithm [pixel].",
         "mode": "REQUIRED",
         "name": "y",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of y.",
+        "description": "Uncertainty of y [pixel].",
         "mode": "NULLABLE",
         "name": "yErr",
         "type": "FLOAT"
@@ -716,13 +716,13 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Flux in a 12 pixel radius aperture on the difference image.",
+        "description": "Flux in a 12 pixel radius aperture on the difference image [nJy].",
         "mode": "NULLABLE",
         "name": "apFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Estimated uncertainty of apFlux.",
+        "description": "Estimated uncertainty of apFlux [nJy].",
         "mode": "NULLABLE",
         "name": "apFluxErr",
         "type": "FLOAT"
@@ -742,7 +742,7 @@
       {
         "description": "Source was detected as significantly negative.",
         "mode": "NULLABLE",
-        "name": "is_negative",
+        "name": "isNegative",
         "type": "BOOLEAN"
       },
       {
@@ -752,13 +752,13 @@
         "type": "FLOAT"
       },
       {
-        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image.",
+        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
         "mode": "NULLABLE",
         "name": "psfFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of psfFlux.",
+        "description": "Uncertainty of psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "psfFluxErr",
         "type": "FLOAT"
@@ -800,61 +800,61 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image.",
+        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
         "mode": "NULLABLE",
         "name": "trailFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailFlux.",
+        "description": "Uncertainty of trailFlux [nJy].",
         "mode": "NULLABLE",
         "name": "trailFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Right ascension coordinate of centroid for trailed source model.",
+        "description": "Right ascension coordinate of centroid for trailed source model [deg].",
         "mode": "NULLABLE",
         "name": "trailRa",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailRa.",
+        "description": "Uncertainty of trailRa [deg].",
         "mode": "NULLABLE",
         "name": "trailRaErr",
         "type": "FLOAT"
       },
       {
-        "description": "Declination coordinate of centroid for trailed source model.",
+        "description": "Declination coordinate of centroid for trailed source model [deg].",
         "mode": "NULLABLE",
         "name": "trailDec",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailDec.",
+        "description": "Uncertainty of trailDec [deg].",
         "mode": "NULLABLE",
         "name": "trailDecErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood fit of trail length.",
+        "description": "Maximum likelihood fit of trail length [arcsec].",
         "mode": "NULLABLE",
         "name": "trailLength",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailLength.",
+        "description": "Uncertainty of trailLength [nJy].",
         "mode": "NULLABLE",
         "name": "trailLengthErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing).",
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing) [deg].",
         "mode": "NULLABLE",
         "name": "trailAngle",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of trailAngle.",
+        "description": "Uncertainty of trailAngle [nJy].",
         "mode": "NULLABLE",
         "name": "trailAngleErr",
         "type": "FLOAT"
@@ -878,37 +878,37 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model.",
+        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleMeanFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dipoleMeanFlux.",
+        "description": "Uncertainty of dipoleMeanFlux [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleMeanFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model.",
+        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleFluxDiff",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dipoleFluxDiff.",
+        "description": "Uncertainty of dipoleFluxDiff [nJy].",
         "mode": "NULLABLE",
         "name": "dipoleFluxDiffErr",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood value for the lobe separation in dipole model.",
+        "description": "Maximum likelihood value for the lobe separation in dipole model [arcsec].",
         "mode": "NULLABLE",
         "name": "dipoleLength",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe).",
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe) [deg].",
         "mode": "NULLABLE",
         "name": "dipoleAngle",
         "type": "FLOAT"
@@ -926,13 +926,13 @@
         "type": "INTEGER"
       },
       {
-        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position.",
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position [nJy].",
         "mode": "NULLABLE",
         "name": "scienceFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Estimated uncertainty of scienceFlux.",
+        "description": "Estimated uncertainty of scienceFlux [nJy].",
         "mode": "NULLABLE",
         "name": "scienceFluxErr",
         "type": "FLOAT"
@@ -956,49 +956,49 @@
         "type": "BOOLEAN"
       },
       {
-        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position.",
+        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position [nJy].",
         "mode": "NULLABLE",
         "name": "templateFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of templateFlux.",
+        "description": "Uncertainty of templateFlux [nJy].",
         "mode": "NULLABLE",
         "name": "templateFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment of the source intensity.",
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixx",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment of the source intensity.",
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "iyy",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment of the source intensity.",
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixy",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment for the PSF.",
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixxPSF",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment for the PSF.",
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "iyyPSF",
         "type": "FLOAT"
       },
       {
-        "description": "Adaptive second moment for the PSF.",
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
         "mode": "NULLABLE",
         "name": "ixyPSF",
         "type": "FLOAT"
@@ -1034,7 +1034,7 @@
         "type": "FLOAT"
       },
       {
-        "description": "A measure of reliability, computed using information from the source and image characterization, as well as the information on the Telescope and Camera system (e.g., ghost maps, defect maps, etc.).",
+        "description": "Probability (0-1) that the diaSource is astrophysical, derived from a machine learning model.",
         "mode": "NULLABLE",
         "name": "reliability",
         "type": "FLOAT"
@@ -1048,7 +1048,7 @@
       {
         "description": "Source well fit by a dipole.",
         "mode": "NULLABLE",
-        "name": "is_dipole",
+        "name": "isDipole",
         "type": "BOOLEAN"
       },
       {
@@ -1064,7 +1064,7 @@
         "type": "TIMESTAMP"
       },
       {
-        "description": "",
+        "description": "Size of the square bounding box that fully contains the detection footprint [pixel].",
         "mode": "NULLABLE",
         "name": "bboxSize",
         "type": "INTEGER"
@@ -1216,13 +1216,13 @@
         "type": "INTEGER"
       },
       {
-        "description": "Right ascension coordinate of the position of the DiaObject.",
+        "description": "Right ascension coordinate of the position of the DiaObject [deg].",
         "mode": "REQUIRED",
         "name": "ra",
         "type": "FLOAT"
       },
       {
-        "description": "Declination coordinate of the position of the DiaObject.",
+        "description": "Declination coordinate of the position of the DiaObject [deg].",
         "mode": "REQUIRED",
         "name": "dec",
         "type": "FLOAT"
@@ -1240,31 +1240,31 @@
         "type": "INTEGER"
       },
       {
-        "description": "Point Source model flux.",
+        "description": "Point Source model flux [nJy].",
         "mode": "NULLABLE",
         "name": "psfFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of psfFlux.",
+        "description": "Uncertainty of psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "psfFluxErr",
         "type": "FLOAT"
       },
       {
-        "description": "Effective mid-visit time for this diaForcedSource, expressed as Modified Julian Date, International Atomic Time.",
+        "description": "Effective mid-visit time for this diaForcedSource, expressed as Modified Julian Date, International Atomic Time [d].",
         "mode": "REQUIRED",
         "name": "midpointMjdTai",
         "type": "FLOAT"
       },
       {
-        "description": "Forced photometry flux for a point source model measured on the visit image centered at the DiaObject position.",
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at the DiaObject position [nJy].",
         "mode": "NULLABLE",
         "name": "scienceFlux",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of scienceFlux.",
+        "description": "Uncertainty of scienceFlux [nJy].",
         "mode": "NULLABLE",
         "name": "scienceFluxErr",
         "type": "FLOAT"
@@ -1302,585 +1302,477 @@
         "type": "TIMESTAMP"
       },
       {
-        "description": "Right ascension coordinate of the position of the object.",
+        "description": "Right ascension coordinate of the position of the object [deg].",
         "mode": "REQUIRED",
         "name": "ra",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of ra.",
+        "description": "Uncertainty of ra [deg].",
         "mode": "NULLABLE",
         "name": "raErr",
         "type": "FLOAT"
       },
       {
-        "description": "Declination coordinate of the position of the object.",
+        "description": "Declination coordinate of the position of the object [deg].",
         "mode": "REQUIRED",
         "name": "dec",
         "type": "FLOAT"
       },
       {
-        "description": "Uncertainty of dec.",
+        "description": "Uncertainty of dec [deg].",
         "mode": "NULLABLE",
         "name": "decErr",
         "type": "FLOAT"
       },
       {
-        "description": "Covariance between ra and dec.",
+        "description": "Covariance between ra and dec [deg**2].",
         "mode": "NULLABLE",
         "name": "ra_dec_Cov",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean point-source model magnitude for u filter.",
+        "description": "Weighted mean point-source model magnitude for u filter [nJy].",
         "mode": "NULLABLE",
         "name": "u_psfFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of u_psfFluxMean.",
+        "description": "Standard error of u_psfFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "u_psfFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of u_psfFlux.",
+        "description": "Standard deviation of the distribution of u_psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "u_psfFluxSigma",
         "type": "FLOAT"
       },
       {
-        "description": "Chi^2 statistic for the scatter of u_psfFlux around u_psfFluxMean.",
-        "mode": "NULLABLE",
-        "name": "u_psfFluxChi2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "The number of data points used to compute u_psfFluxChi2.",
+        "description": "The number of u-band data points.",
         "mode": "NULLABLE",
         "name": "u_psfFluxNdata",
         "type": "INTEGER"
       },
       {
-        "description": "Weighted mean forced photometry flux for u filter.",
+        "description": "Weighted mean forced photometry flux for u filter [nJy].",
         "mode": "NULLABLE",
         "name": "u_fpFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of u_fpFluxMean.",
+        "description": "Standard error of u_fpFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "u_fpFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean point-source model magnitude for g filter.",
+        "description": "Weighted mean point-source model magnitude for g filter [nJy].",
         "mode": "NULLABLE",
         "name": "g_psfFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of g_psfFluxMean.",
+        "description": "Standard error of g_psfFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "g_psfFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of g_psfFlux.",
+        "description": "Standard deviation of the distribution of g_psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "g_psfFluxSigma",
         "type": "FLOAT"
       },
       {
-        "description": "Chi^2 statistic for the scatter of g_psfFlux around g_psfFluxMean.",
-        "mode": "NULLABLE",
-        "name": "g_psfFluxChi2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "The number of data points used to compute g_psfFluxChi2.",
+        "description": "The number of g-band data points.",
         "mode": "NULLABLE",
         "name": "g_psfFluxNdata",
         "type": "INTEGER"
       },
       {
-        "description": "Weighted mean forced photometry flux for g filter.",
+        "description": "Weighted mean forced photometry flux for g filter [nJy].",
         "mode": "NULLABLE",
         "name": "g_fpFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of g_fpFluxMean.",
+        "description": "Standard error of g_fpFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "g_fpFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean point-source model magnitude for r filter.",
+        "description": "Weighted mean point-source model magnitude for r filter [nJy].",
         "mode": "NULLABLE",
         "name": "r_psfFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of r_psfFluxMean.",
+        "description": "Standard error of r_psfFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "r_psfFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of r_psfFlux.",
+        "description": "Standard deviation of the distribution of r_psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "r_psfFluxSigma",
         "type": "FLOAT"
       },
       {
-        "description": "Chi^2 statistic for the scatter of r_psfFlux around r_psfFluxMean.",
-        "mode": "NULLABLE",
-        "name": "r_psfFluxChi2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "The number of data points used to compute r_psfFluxChi2.",
+        "description": "The number of r-band data points.",
         "mode": "NULLABLE",
         "name": "r_psfFluxNdata",
         "type": "INTEGER"
       },
       {
-        "description": "Weighted mean forced photometry flux for r filter.",
+        "description": "Weighted mean forced photometry flux for r filter [nJy].",
         "mode": "NULLABLE",
         "name": "r_fpFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of r_fpFluxMean.",
+        "description": "Standard error of r_fpFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "r_fpFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean point-source model magnitude for i filter.",
+        "description": "Weighted mean point-source model magnitude for i filter [nJy].",
         "mode": "NULLABLE",
         "name": "i_psfFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of i_psfFluxMean.",
+        "description": "Standard error of i_psfFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "i_psfFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of i_psfFlux.",
+        "description": "Standard deviation of the distribution of i_psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "i_psfFluxSigma",
         "type": "FLOAT"
       },
       {
-        "description": "Chi^2 statistic for the scatter of i_psfFlux around i_psfFluxMean.",
-        "mode": "NULLABLE",
-        "name": "i_psfFluxChi2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "The number of data points used to compute i_psfFluxChi2.",
+        "description": "The number of i-band data points.",
         "mode": "NULLABLE",
         "name": "i_psfFluxNdata",
         "type": "INTEGER"
       },
       {
-        "description": "Weighted mean forced photometry flux for i filter.",
+        "description": "Weighted mean forced photometry flux for i filter [nJy].",
         "mode": "NULLABLE",
         "name": "i_fpFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of i_fpFluxMean.",
+        "description": "Standard error of i_fpFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "i_fpFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean point-source model magnitude for z filter.",
+        "description": "Weighted mean point-source model magnitude for z filter [nJy].",
         "mode": "NULLABLE",
         "name": "z_psfFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of z_psfFluxMean.",
+        "description": "Standard error of z_psfFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "z_psfFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of z_psfFlux.",
+        "description": "Standard deviation of the distribution of z_psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "z_psfFluxSigma",
         "type": "FLOAT"
       },
       {
-        "description": "Chi^2 statistic for the scatter of z_psfFlux around z_psfFluxMean.",
-        "mode": "NULLABLE",
-        "name": "z_psfFluxChi2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "The number of data points used to compute z_psfFluxChi2.",
+        "description": "The number of z-band data points.",
         "mode": "NULLABLE",
         "name": "z_psfFluxNdata",
         "type": "INTEGER"
       },
       {
-        "description": "Weighted mean forced photometry flux for z filter.",
+        "description": "Weighted mean forced photometry flux for z filter [nJy].",
         "mode": "NULLABLE",
         "name": "z_fpFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of z_fpFluxMean.",
+        "description": "Standard error of z_fpFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "z_fpFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean point-source model magnitude for y filter.",
+        "description": "Weighted mean point-source model magnitude for y filter [nJy].",
         "mode": "NULLABLE",
         "name": "y_psfFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of y_psfFluxMean.",
+        "description": "Standard error of y_psfFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "y_psfFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of y_psfFlux.",
+        "description": "Standard deviation of the distribution of y_psfFlux [nJy].",
         "mode": "NULLABLE",
         "name": "y_psfFluxSigma",
         "type": "FLOAT"
       },
       {
-        "description": "Chi^2 statistic for the scatter of y_psfFlux around y_psfFluxMean.",
-        "mode": "NULLABLE",
-        "name": "y_psfFluxChi2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "The number of data points used to compute y_psfFluxChi2.",
+        "description": "The number of y-band data points.",
         "mode": "NULLABLE",
         "name": "y_psfFluxNdata",
         "type": "INTEGER"
       },
       {
-        "description": "Weighted mean forced photometry flux for y filter.",
+        "description": "Weighted mean forced photometry flux for y filter [nJy].",
         "mode": "NULLABLE",
         "name": "y_fpFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of y_fpFluxMean.",
+        "description": "Standard error of y_fpFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "y_fpFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Weighted mean forced photometry flux for u filter.",
+        "description": "Weighted mean forced photometry flux for u filter [nJy].",
         "mode": "NULLABLE",
         "name": "u_scienceFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of u_scienceFluxMean.",
+        "description": "Standard error of u_scienceFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "u_scienceFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of u_scienceFlux.",
-        "mode": "NULLABLE",
-        "name": "u_scienceFluxSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Weighted mean forced photometry flux for g filter.",
+        "description": "Weighted mean forced photometry flux for g filter [nJy].",
         "mode": "NULLABLE",
         "name": "g_scienceFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of g_scienceFluxMean.",
+        "description": "Standard error of g_scienceFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "g_scienceFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of g_scienceFlux.",
-        "mode": "NULLABLE",
-        "name": "g_scienceFluxSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Weighted mean forced photometry flux for r filter.",
+        "description": "Weighted mean forced photometry flux for r filter [nJy].",
         "mode": "NULLABLE",
         "name": "r_scienceFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of r_scienceFluxMean.",
+        "description": "Standard error of r_scienceFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "r_scienceFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of r_scienceFlux.",
-        "mode": "NULLABLE",
-        "name": "r_scienceFluxSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Weighted mean forced photometry flux for i filter.",
+        "description": "Weighted mean forced photometry flux for i filter [nJy].",
         "mode": "NULLABLE",
         "name": "i_scienceFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of i_scienceFluxMean.",
+        "description": "Standard error of i_scienceFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "i_scienceFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of i_scienceFlux.",
-        "mode": "NULLABLE",
-        "name": "i_scienceFluxSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Weighted mean forced photometry flux for z filter.",
+        "description": "Weighted mean forced photometry flux for z filter [nJy].",
         "mode": "NULLABLE",
         "name": "z_scienceFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of z_scienceFluxMean.",
+        "description": "Standard error of z_scienceFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "z_scienceFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of z_scienceFlux.",
-        "mode": "NULLABLE",
-        "name": "z_scienceFluxSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Weighted mean forced photometry flux for y filter.",
+        "description": "Weighted mean forced photometry flux for y filter [nJy].",
         "mode": "NULLABLE",
         "name": "y_scienceFluxMean",
         "type": "FLOAT"
       },
       {
-        "description": "Standard error of y_scienceFluxMean.",
+        "description": "Standard error of y_scienceFluxMean [nJy].",
         "mode": "NULLABLE",
         "name": "y_scienceFluxMeanErr",
         "type": "FLOAT"
       },
       {
-        "description": "Standard deviation of the distribution of y_scienceFlux.",
-        "mode": "NULLABLE",
-        "name": "y_scienceFluxSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Skewness of the u band fluxes.",
-        "mode": "NULLABLE",
-        "name": "u_psfFluxSkew",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Minimum observed u band fluxes.",
+        "description": "Minimum observed u band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "u_psfFluxMin",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum observed u band fluxes.",
+        "description": "Maximum observed u band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "u_psfFluxMax",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum slope between u band flux obsevations max(delta_flux/delta_time).",
+        "description": "Maximum slope between u band flux obsevations max(delta_flux/delta_time) [nJy/d].",
         "mode": "NULLABLE",
         "name": "u_psfFluxMaxSlope",
         "type": "FLOAT"
       },
       {
-        "description": "Mean of the u band flux errors.",
+        "description": "Mean of the u band flux errors [nJy].",
         "mode": "NULLABLE",
         "name": "u_psfFluxErrMean",
         "type": "FLOAT"
       },
       {
-        "description": "Skewness of the g band fluxes.",
-        "mode": "NULLABLE",
-        "name": "g_psfFluxSkew",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Minimum observed g band fluxes.",
+        "description": "Minimum observed g band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "g_psfFluxMin",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum observed g band fluxes.",
+        "description": "Maximum observed g band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "g_psfFluxMax",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum slope between g band flux obsevations max(delta_flux/delta_time).",
+        "description": "Maximum slope between g band flux obsevations max(delta_flux/delta_time) [nJy/d].",
         "mode": "NULLABLE",
         "name": "g_psfFluxMaxSlope",
         "type": "FLOAT"
       },
       {
-        "description": "Mean of the g band flux errors.",
+        "description": "Mean of the g band flux errors [nJy].",
         "mode": "NULLABLE",
         "name": "g_psfFluxErrMean",
         "type": "FLOAT"
       },
       {
-        "description": "Skewness of the r band fluxes.",
-        "mode": "NULLABLE",
-        "name": "r_psfFluxSkew",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Minimum observed r band fluxes.",
+        "description": "Minimum observed r band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "r_psfFluxMin",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum observed r band fluxes.",
+        "description": "Maximum observed r band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "r_psfFluxMax",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum slope between r band flux obsevations max(delta_flux/delta_time).",
+        "description": "Maximum slope between r band flux obsevations max(delta_flux/delta_time) [nJy/d].",
         "mode": "NULLABLE",
         "name": "r_psfFluxMaxSlope",
         "type": "FLOAT"
       },
       {
-        "description": "Mean of the r band flux errors.",
+        "description": "Mean of the r band flux errors [nJy].",
         "mode": "NULLABLE",
         "name": "r_psfFluxErrMean",
         "type": "FLOAT"
       },
       {
-        "description": "Skewness of the i band fluxes.",
-        "mode": "NULLABLE",
-        "name": "i_psfFluxSkew",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Minimum observed i band fluxes.",
+        "description": "Minimum observed i band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "i_psfFluxMin",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum observed i band fluxes.",
+        "description": "Maximum observed i band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "i_psfFluxMax",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum slope between i band flux obsevations max(delta_flux/delta_time).",
+        "description": "Maximum slope between i band flux obsevations max(delta_flux/delta_time) [nJy/d].",
         "mode": "NULLABLE",
         "name": "i_psfFluxMaxSlope",
         "type": "FLOAT"
       },
       {
-        "description": "Mean of the i band flux errors.",
+        "description": "Mean of the i band flux errors [nJy].",
         "mode": "NULLABLE",
         "name": "i_psfFluxErrMean",
         "type": "FLOAT"
       },
       {
-        "description": "Skewness of the z band fluxes.",
-        "mode": "NULLABLE",
-        "name": "z_psfFluxSkew",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Minimum observed z band fluxes.",
+        "description": "Minimum observed z band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "z_psfFluxMin",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum observed z band fluxes.",
+        "description": "Maximum observed z band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "z_psfFluxMax",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum slope between z band flux obsevations max(delta_flux/delta_time).",
+        "description": "Maximum slope between z band flux obsevations max(delta_flux/delta_time) [nJy/d].",
         "mode": "NULLABLE",
         "name": "z_psfFluxMaxSlope",
         "type": "FLOAT"
       },
       {
-        "description": "Mean of the z band flux errors.",
+        "description": "Mean of the z band flux errors [nJy].",
         "mode": "NULLABLE",
         "name": "z_psfFluxErrMean",
         "type": "FLOAT"
       },
       {
-        "description": "Skewness of the y band fluxes.",
-        "mode": "NULLABLE",
-        "name": "y_psfFluxSkew",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Minimum observed y band fluxes.",
+        "description": "Minimum observed y band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "y_psfFluxMin",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum observed y band fluxes.",
+        "description": "Maximum observed y band fluxes [nJy].",
         "mode": "NULLABLE",
         "name": "y_psfFluxMax",
         "type": "FLOAT"
       },
       {
-        "description": "Maximum slope between y band flux obsevations max(delta_flux/delta_time).",
+        "description": "Maximum slope between y band flux obsevations max(delta_flux/delta_time) [nJy/d].",
         "mode": "NULLABLE",
         "name": "y_psfFluxMaxSlope",
         "type": "FLOAT"
       },
       {
-        "description": "Mean of the y band flux errors.",
+        "description": "Mean of the y band flux errors [nJy].",
         "mode": "NULLABLE",
         "name": "y_psfFluxErrMean",
         "type": "FLOAT"
       },
       {
-        "description": "Last time when non-forced DIASource was seen for this object.",
-        "mode": "REQUIRED",
-        "name": "lastNonForcedSource",
-        "type": "TIMESTAMP"
+        "description": "Time of the first diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "firstDiaSourceMjdTai",
+        "type": "FLOAT"
       },
       {
-        "description": "Time of the first diaSource, expressed as Modified Julian Date, International Atomic Time.",
-        "mode": "REQUIRED",
-        "name": "firstDiaSourceMjdTai",
+        "description": "Time of the most recent non-forced DIASource for this object, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "lastDiaSourceMjdTai",
         "type": "FLOAT"
       },
       {
@@ -1910,271 +1802,133 @@
         "type": "INTEGER"
       },
       {
-        "description": "MPC unique identifier of the observation.",
-        "mode": "NULLABLE",
-        "name": "mpcUniqueId",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
-        "mode": "NULLABLE",
-        "name": "nearbyObj1",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
-        "mode": "NULLABLE",
-        "name": "nearbyObj2",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
-        "mode": "NULLABLE",
-        "name": "nearbyObj3",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
-        "mode": "NULLABLE",
-        "name": "nearbyObj4",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
-        "mode": "NULLABLE",
-        "name": "nearbyObj5",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
-        "mode": "NULLABLE",
-        "name": "nearbyObj6",
-        "type": "INTEGER"
-      },
-      {
-        "description": "Distances to nearbyObj.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjDist1",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Distances to nearbyObj.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjDist2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Distances to nearbyObj.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjDist3",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Distances to nearbyObj.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjDist4",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Distances to nearbyObj.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjDist5",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Distances to nearbyObj.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjDist6",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjLnP1",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjLnP2",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjLnP3",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjLnP4",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjLnP5",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
-        "mode": "NULLABLE",
-        "name": "nearbyObjLnP6",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Ecliptic longitude.",
+        "description": "Ecliptic longitude [deg].",
         "mode": "NULLABLE",
         "name": "eclipticLambda",
         "type": "FLOAT"
       },
       {
-        "description": "Ecliptic latitude.",
+        "description": "Ecliptic latitude [deg].",
         "mode": "NULLABLE",
         "name": "eclipticBeta",
         "type": "FLOAT"
       },
       {
-        "description": "Galactic longitude.",
+        "description": "Galactic longitude [deg].",
         "mode": "NULLABLE",
         "name": "galacticL",
         "type": "FLOAT"
       },
       {
-        "description": "Galactic latitute.",
+        "description": "Galactic latitute [deg].",
         "mode": "NULLABLE",
         "name": "galacticB",
         "type": "FLOAT"
       },
       {
-        "description": "Phase angle.",
+        "description": "Phase angle [deg].",
         "mode": "NULLABLE",
         "name": "phaseAngle",
         "type": "FLOAT"
       },
       {
-        "description": "Heliocentric distance.",
+        "description": "Heliocentric distance [AU].",
         "mode": "NULLABLE",
         "name": "heliocentricDist",
         "type": "FLOAT"
       },
       {
-        "description": "Topocentric distace.",
+        "description": "Topocentric distace [AU].",
         "mode": "NULLABLE",
         "name": "topocentricDist",
         "type": "FLOAT"
       },
       {
-        "description": "Predicted magnitude.",
+        "description": "Predicted V-band magnitude [mag].",
         "mode": "NULLABLE",
-        "name": "predictedMagnitude",
+        "name": "predictedVMagnitude",
         "type": "FLOAT"
       },
       {
-        "description": "Prediction uncertainty (1-sigma).",
-        "mode": "NULLABLE",
-        "name": "predictedMagnitudeSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Residual R.A. vs. ephemeris.",
+        "description": "Residual R.A. vs. ephemeris [deg].",
         "mode": "NULLABLE",
         "name": "residualRa",
         "type": "FLOAT"
       },
       {
-        "description": "Residual Dec vs. ephemeris.",
+        "description": "Residual Dec vs. ephemeris [deg].",
         "mode": "NULLABLE",
         "name": "residualDec",
         "type": "FLOAT"
       },
       {
-        "description": "Predicted R.A. uncertainty.",
-        "mode": "NULLABLE",
-        "name": "predictedRaSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Predicted Dec uncertainty.",
-        "mode": "NULLABLE",
-        "name": "predictedDecSigma",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Predicted R.A./Dec covariance.",
-        "mode": "NULLABLE",
-        "name": "predictedRaDecCov",
-        "type": "FLOAT"
-      },
-      {
-        "description": "Cartesian heliocentric X coordinate (at the emit time).",
+        "description": "Cartesian heliocentric X coordinate (at the emit time) [AU].",
         "mode": "NULLABLE",
         "name": "heliocentricX",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian heliocentric Y coordinate (at the emit time).",
+        "description": "Cartesian heliocentric Y coordinate (at the emit time) [AU].",
         "mode": "NULLABLE",
         "name": "heliocentricY",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian heliocentric Z coordinate (at the emit time).",
+        "description": "Cartesian heliocentric Z coordinate (at the emit time) [AU].",
         "mode": "NULLABLE",
         "name": "heliocentricZ",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian heliocentric X velocity (at the emit time).",
+        "description": "Cartesian heliocentric X velocity (at the emit time) [AU/d].",
         "mode": "NULLABLE",
         "name": "heliocentricVX",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian heliocentric Y velocity (at the emit time).",
+        "description": "Cartesian heliocentric Y velocity (at the emit time) [AU/d].",
         "mode": "NULLABLE",
         "name": "heliocentricVY",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian heliocentric Z velocity (at the emit time).",
+        "description": "Cartesian heliocentric Z velocity (at the emit time) [AU/d].",
         "mode": "NULLABLE",
         "name": "heliocentricVZ",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian topocentric X coordinate (at the emit time).",
+        "description": "Cartesian topocentric X coordinate (at the emit time) [AU].",
         "mode": "NULLABLE",
         "name": "topocentricX",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian topocentric Y coordinate (at the emit time).",
+        "description": "Cartesian topocentric Y coordinate (at the emit time) [AU].",
         "mode": "NULLABLE",
         "name": "topocentricY",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian topocentric Z coordinate (at the emit time).",
+        "description": "Cartesian topocentric Z coordinate (at the emit time) [AU].",
         "mode": "NULLABLE",
         "name": "topocentricZ",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian topocentric X velocity (at the emit time).",
+        "description": "Cartesian topocentric X velocity (at the emit time) [AU/d].",
         "mode": "NULLABLE",
         "name": "topocentricVX",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian topocentric Y velocity (at the emit time).",
+        "description": "Cartesian topocentric Y velocity (at the emit time) [AU/d].",
         "mode": "NULLABLE",
         "name": "topocentricVY",
         "type": "FLOAT"
       },
       {
-        "description": "Cartesian topocentric Z velocity (at the emit time).",
+        "description": "Cartesian topocentric Z velocity (at the emit time) [AU/d].",
         "mode": "NULLABLE",
         "name": "topocentricVZ",
         "type": "FLOAT"
@@ -2200,37 +1954,37 @@
         "type": "INTEGER"
       },
       {
-        "description": "Absolute magnitude, H.",
+        "description": "Absolute magnitude, H [mag].",
         "mode": "NULLABLE",
         "name": "mpcH",
         "type": "FLOAT"
       },
       {
-        "description": "Epoch (in MJD, .0 TT).",
+        "description": "Epoch (in MJD, .0 TT) [d].",
         "mode": "NULLABLE",
         "name": "epoch",
         "type": "FLOAT"
       },
       {
-        "description": "Mean anomaly at the epoch, in degrees.",
+        "description": "Mean anomaly at the epoch [deg].",
         "mode": "NULLABLE",
         "name": "M",
         "type": "FLOAT"
       },
       {
-        "description": "Argument of perihelion, J2000.0 (degrees).",
+        "description": "Argument of perihelion, J2000.0 [deg].",
         "mode": "NULLABLE",
         "name": "peri",
         "type": "FLOAT"
       },
       {
-        "description": "Longitude of the ascending node, J2000.0 (degrees).",
+        "description": "Longitude of the ascending node, J2000.0 [deg].",
         "mode": "NULLABLE",
         "name": "node",
         "type": "FLOAT"
       },
       {
-        "description": "Inclination to the ecliptic, J2000.0 (degrees).",
+        "description": "Inclination to the ecliptic, J2000.0 [deg].",
         "mode": "NULLABLE",
         "name": "incl",
         "type": "FLOAT"
@@ -2242,41 +1996,23 @@
         "type": "FLOAT"
       },
       {
-        "description": "Semimajor axis (AU).",
+        "description": "Semimajor axis [AU].",
         "mode": "NULLABLE",
         "name": "a",
         "type": "FLOAT"
       },
       {
-        "description": "Perihelion distance (AU).",
+        "description": "Perihelion distance [AU].",
         "mode": "NULLABLE",
         "name": "q",
         "type": "FLOAT"
       },
       {
-        "description": "MJD of pericentric passage.",
+        "description": "MJD of pericentric passage [d].",
         "mode": "NULLABLE",
         "name": "t_p",
         "type": "FLOAT"
       }
     ]
-  },
-  {
-    "description": "",
-    "mode": "NULLABLE",
-    "name": "cutoutDifference",
-    "type": "BYTES"
-  },
-  {
-    "description": "",
-    "mode": "NULLABLE",
-    "name": "cutoutScience",
-    "type": "BYTES"
-  },
-  {
-    "description": "",
-    "mode": "NULLABLE",
-    "name": "cutoutTemplate",
-    "type": "BYTES"
   }
 ]

--- a/broker/setup_broker/lsst/templates/bq_lsst_alerts_v8_0_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_alerts_v8_0_schema.json
@@ -1,0 +1,2282 @@
+[
+  {
+    "description": "Identifier of the triggering DiaSource",
+    "mode": "REQUIRED",
+    "name": "diaSourceId",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Scheduler reason for the image containing this diaSource.",
+    "mode": "NULLABLE",
+    "name": "observation_reason",
+    "type": "STRING"
+  },
+  {
+    "description": "Scheduler target for the image containing this diaSource.",
+    "mode": "NULLABLE",
+    "name": "target_name",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "mode": "REQUIRED",
+    "name": "diaSource",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of this DiaSource.",
+        "mode": "REQUIRED",
+        "name": "diaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the visit where this diaSource was measured.",
+        "mode": "REQUIRED",
+        "name": "visit",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the detector where this diaSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes.",
+        "mode": "REQUIRED",
+        "name": "detector",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the diaObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the ssObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the parent diaSource this diaSource has been deblended from, if any.",
+        "mode": "NULLABLE",
+        "name": "parentDiaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "midpointMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of the center of this diaSource.",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of ra.",
+        "mode": "NULLABLE",
+        "name": "raErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the center of this diaSource.",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dec.",
+        "mode": "NULLABLE",
+        "name": "decErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Covariance between ra and dec.",
+        "mode": "NULLABLE",
+        "name": "ra_dec_Cov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "x position computed by a centroiding algorithm.",
+        "mode": "REQUIRED",
+        "name": "x",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of x.",
+        "mode": "NULLABLE",
+        "name": "xErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "y position computed by a centroiding algorithm.",
+        "mode": "REQUIRED",
+        "name": "y",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of y.",
+        "mode": "NULLABLE",
+        "name": "yErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General centroid algorithm failure flag; set if anything went wrong when fitting the centroid. Another centroid flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "centroid_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux in a 12 pixel radius aperture on the difference image.",
+        "mode": "NULLABLE",
+        "name": "apFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of apFlux.",
+        "mode": "NULLABLE",
+        "name": "apFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General aperture flux algorithm failure flag; set if anything went wrong when measuring aperture fluxes. Another apFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Aperture did not fit within measurement image.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag_apertureTruncated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Source was detected as significantly negative.",
+        "mode": "NULLABLE",
+        "name": "is_negative",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "The signal-to-noise ratio at which this source was detected in the difference image.",
+        "mode": "NULLABLE",
+        "name": "snr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image.",
+        "mode": "NULLABLE",
+        "name": "psfFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of psfFlux.",
+        "mode": "NULLABLE",
+        "name": "psfFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log likelihood of the observed data given the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfLnL",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the point source model fit.",
+        "mode": "NULLABLE",
+        "name": "psfChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Failure to derive linear least-squares fit of psf model. Another psfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Object was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image.",
+        "mode": "NULLABLE",
+        "name": "trailFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailFlux.",
+        "mode": "NULLABLE",
+        "name": "trailFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of centroid for trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailRa.",
+        "mode": "NULLABLE",
+        "name": "trailRaErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of centroid for trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailDec.",
+        "mode": "NULLABLE",
+        "name": "trailDecErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of trail length.",
+        "mode": "NULLABLE",
+        "name": "trailLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailLength.",
+        "mode": "NULLABLE",
+        "name": "trailLengthErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing).",
+        "mode": "NULLABLE",
+        "name": "trailAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailAngle.",
+        "mode": "NULLABLE",
+        "name": "trailAngleErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the trailed source model fit.",
+        "mode": "NULLABLE",
+        "name": "trailChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "This flag is set if a trailed source extends onto or past edge pixels.",
+        "mode": "NULLABLE",
+        "name": "trail_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model.",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleMeanFlux.",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model.",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiff",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleFluxDiff.",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiffErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the lobe separation in dipole model.",
+        "mode": "NULLABLE",
+        "name": "dipoleLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe).",
+        "mode": "NULLABLE",
+        "name": "dipoleAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the model fit.",
+        "mode": "NULLABLE",
+        "name": "dipoleChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the model.",
+        "mode": "NULLABLE",
+        "name": "dipoleNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position.",
+        "mode": "NULLABLE",
+        "name": "scienceFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "scienceFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux on science image was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position.",
+        "mode": "NULLABLE",
+        "name": "templateFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of templateFlux.",
+        "mode": "NULLABLE",
+        "name": "templateFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity.",
+        "mode": "NULLABLE",
+        "name": "ixx",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity.",
+        "mode": "NULLABLE",
+        "name": "iyy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity.",
+        "mode": "NULLABLE",
+        "name": "ixy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF.",
+        "mode": "NULLABLE",
+        "name": "ixxPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF.",
+        "mode": "NULLABLE",
+        "name": "iyyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF.",
+        "mode": "NULLABLE",
+        "name": "ixyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General source shape algorithm failure flag; set if anything went wrong when measuring the shape. Another shape flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "shape_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "No pixels to measure shape.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_no_pixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Center not contained in footprint bounding box.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_not_contained",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This source is a parent source; we should only be measuring on deblended children in difference imaging.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_parent_source",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "A measure of extendedness, computed by comparing an object's moment-based traced radius to the PSF moments. extendedness = 1 implies a high degree of confidence that the source is extended. extendedness = 0 implies a high degree of confidence that the source is point-like.",
+        "mode": "NULLABLE",
+        "name": "extendedness",
+        "type": "FLOAT"
+      },
+      {
+        "description": "A measure of reliability, computed using information from the source and image characterization, as well as the information on the Telescope and Camera system (e.g., ghost maps, defect maps, etc.).",
+        "mode": "NULLABLE",
+        "name": "reliability",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Filter band this source was observed with.",
+        "mode": "NULLABLE",
+        "name": "band",
+        "type": "STRING"
+      },
+      {
+        "description": "Source well fit by a dipole.",
+        "mode": "NULLABLE",
+        "name": "is_dipole",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Attempted to fit a dipole model to this source.",
+        "mode": "NULLABLE",
+        "name": "dipoleFitAttempted",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Time when the image was processed and this DiaSource record was generated.",
+        "mode": "REQUIRED",
+        "name": "time_processed",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "bboxSize",
+        "type": "INTEGER"
+      },
+      {
+        "description": "General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Bad pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_bad",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_cr",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_crCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image).",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the source footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodata",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodataCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource center is off image.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_offimage",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource's footprint includes suspect pixels.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspect",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Suspect pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspectCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streak",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streakCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injectedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_template",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_templateCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This flag is set if the source is part of a glint trail.",
+        "mode": "NULLABLE",
+        "name": "glint_trail",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "prvDiaSources",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of this DiaSource.",
+        "mode": "REQUIRED",
+        "name": "diaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the visit where this diaSource was measured.",
+        "mode": "REQUIRED",
+        "name": "visit",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the detector where this diaSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes.",
+        "mode": "REQUIRED",
+        "name": "detector",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the diaObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the ssObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the parent diaSource this diaSource has been deblended from, if any.",
+        "mode": "NULLABLE",
+        "name": "parentDiaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "midpointMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of the center of this diaSource.",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of ra.",
+        "mode": "NULLABLE",
+        "name": "raErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the center of this diaSource.",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dec.",
+        "mode": "NULLABLE",
+        "name": "decErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Covariance between ra and dec.",
+        "mode": "NULLABLE",
+        "name": "ra_dec_Cov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "x position computed by a centroiding algorithm.",
+        "mode": "REQUIRED",
+        "name": "x",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of x.",
+        "mode": "NULLABLE",
+        "name": "xErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "y position computed by a centroiding algorithm.",
+        "mode": "REQUIRED",
+        "name": "y",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of y.",
+        "mode": "NULLABLE",
+        "name": "yErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General centroid algorithm failure flag; set if anything went wrong when fitting the centroid. Another centroid flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "centroid_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux in a 12 pixel radius aperture on the difference image.",
+        "mode": "NULLABLE",
+        "name": "apFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of apFlux.",
+        "mode": "NULLABLE",
+        "name": "apFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General aperture flux algorithm failure flag; set if anything went wrong when measuring aperture fluxes. Another apFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Aperture did not fit within measurement image.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag_apertureTruncated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Source was detected as significantly negative.",
+        "mode": "NULLABLE",
+        "name": "is_negative",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "The signal-to-noise ratio at which this source was detected in the difference image.",
+        "mode": "NULLABLE",
+        "name": "snr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image.",
+        "mode": "NULLABLE",
+        "name": "psfFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of psfFlux.",
+        "mode": "NULLABLE",
+        "name": "psfFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log likelihood of the observed data given the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfLnL",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the point source model fit.",
+        "mode": "NULLABLE",
+        "name": "psfChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Failure to derive linear least-squares fit of psf model. Another psfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Object was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image.",
+        "mode": "NULLABLE",
+        "name": "trailFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailFlux.",
+        "mode": "NULLABLE",
+        "name": "trailFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of centroid for trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailRa.",
+        "mode": "NULLABLE",
+        "name": "trailRaErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of centroid for trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailDec.",
+        "mode": "NULLABLE",
+        "name": "trailDecErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of trail length.",
+        "mode": "NULLABLE",
+        "name": "trailLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailLength.",
+        "mode": "NULLABLE",
+        "name": "trailLengthErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing).",
+        "mode": "NULLABLE",
+        "name": "trailAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailAngle.",
+        "mode": "NULLABLE",
+        "name": "trailAngleErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the trailed source model fit.",
+        "mode": "NULLABLE",
+        "name": "trailChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "This flag is set if a trailed source extends onto or past edge pixels.",
+        "mode": "NULLABLE",
+        "name": "trail_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model.",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleMeanFlux.",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model.",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiff",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleFluxDiff.",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiffErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the lobe separation in dipole model.",
+        "mode": "NULLABLE",
+        "name": "dipoleLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe).",
+        "mode": "NULLABLE",
+        "name": "dipoleAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the model fit.",
+        "mode": "NULLABLE",
+        "name": "dipoleChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the model.",
+        "mode": "NULLABLE",
+        "name": "dipoleNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position.",
+        "mode": "NULLABLE",
+        "name": "scienceFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "scienceFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux on science image was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position.",
+        "mode": "NULLABLE",
+        "name": "templateFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of templateFlux.",
+        "mode": "NULLABLE",
+        "name": "templateFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity.",
+        "mode": "NULLABLE",
+        "name": "ixx",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity.",
+        "mode": "NULLABLE",
+        "name": "iyy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity.",
+        "mode": "NULLABLE",
+        "name": "ixy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF.",
+        "mode": "NULLABLE",
+        "name": "ixxPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF.",
+        "mode": "NULLABLE",
+        "name": "iyyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF.",
+        "mode": "NULLABLE",
+        "name": "ixyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General source shape algorithm failure flag; set if anything went wrong when measuring the shape. Another shape flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "shape_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "No pixels to measure shape.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_no_pixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Center not contained in footprint bounding box.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_not_contained",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This source is a parent source; we should only be measuring on deblended children in difference imaging.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_parent_source",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "A measure of extendedness, computed by comparing an object's moment-based traced radius to the PSF moments. extendedness = 1 implies a high degree of confidence that the source is extended. extendedness = 0 implies a high degree of confidence that the source is point-like.",
+        "mode": "NULLABLE",
+        "name": "extendedness",
+        "type": "FLOAT"
+      },
+      {
+        "description": "A measure of reliability, computed using information from the source and image characterization, as well as the information on the Telescope and Camera system (e.g., ghost maps, defect maps, etc.).",
+        "mode": "NULLABLE",
+        "name": "reliability",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Filter band this source was observed with.",
+        "mode": "NULLABLE",
+        "name": "band",
+        "type": "STRING"
+      },
+      {
+        "description": "Source well fit by a dipole.",
+        "mode": "NULLABLE",
+        "name": "is_dipole",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Attempted to fit a dipole model to this source.",
+        "mode": "NULLABLE",
+        "name": "dipoleFitAttempted",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Time when the image was processed and this DiaSource record was generated.",
+        "mode": "REQUIRED",
+        "name": "time_processed",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "",
+        "mode": "NULLABLE",
+        "name": "bboxSize",
+        "type": "INTEGER"
+      },
+      {
+        "description": "General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Bad pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_bad",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_cr",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_crCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image).",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the source footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodata",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodataCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource center is off image.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_offimage",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource's footprint includes suspect pixels.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspect",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Suspect pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspectCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streak",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streakCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injectedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_template",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_templateCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This flag is set if the source is part of a glint trail.",
+        "mode": "NULLABLE",
+        "name": "glint_trail",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "prvDiaForcedSources",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique id.",
+        "mode": "REQUIRED",
+        "name": "diaForcedSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the DiaObject that this DiaForcedSource was associated with.",
+        "mode": "REQUIRED",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Right ascension coordinate of the position of the DiaObject.",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the position of the DiaObject.",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Id of the visit where this forcedSource was measured.",
+        "mode": "REQUIRED",
+        "name": "visit",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the detector where this forcedSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes.",
+        "mode": "REQUIRED",
+        "name": "detector",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Point Source model flux.",
+        "mode": "NULLABLE",
+        "name": "psfFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of psfFlux.",
+        "mode": "NULLABLE",
+        "name": "psfFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Effective mid-visit time for this diaForcedSource, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "midpointMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at the DiaObject position.",
+        "mode": "NULLABLE",
+        "name": "scienceFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "scienceFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Filter band this source was observed with.",
+        "mode": "NULLABLE",
+        "name": "band",
+        "type": "STRING"
+      },
+      {
+        "description": "Time when this record was generated.",
+        "mode": "REQUIRED",
+        "name": "time_processed",
+        "type": "TIMESTAMP"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "diaObject",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of this DiaObject.",
+        "mode": "REQUIRED",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Processing time when validity of this diaObject starts.",
+        "mode": "REQUIRED",
+        "name": "validityStart",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "Right ascension coordinate of the position of the object.",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of ra.",
+        "mode": "NULLABLE",
+        "name": "raErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the position of the object.",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dec.",
+        "mode": "NULLABLE",
+        "name": "decErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Covariance between ra and dec.",
+        "mode": "NULLABLE",
+        "name": "ra_dec_Cov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for u filter.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of u_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of u_psfFlux.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic for the scatter of u_psfFlux around u_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points used to compute u_psfFluxChi2.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for u filter.",
+        "mode": "NULLABLE",
+        "name": "u_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of u_fpFluxMean.",
+        "mode": "NULLABLE",
+        "name": "u_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for g filter.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of g_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of g_psfFlux.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic for the scatter of g_psfFlux around g_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points used to compute g_psfFluxChi2.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for g filter.",
+        "mode": "NULLABLE",
+        "name": "g_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of g_fpFluxMean.",
+        "mode": "NULLABLE",
+        "name": "g_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for r filter.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of r_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of r_psfFlux.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic for the scatter of r_psfFlux around r_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points used to compute r_psfFluxChi2.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for r filter.",
+        "mode": "NULLABLE",
+        "name": "r_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of r_fpFluxMean.",
+        "mode": "NULLABLE",
+        "name": "r_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for i filter.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of i_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of i_psfFlux.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic for the scatter of i_psfFlux around i_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points used to compute i_psfFluxChi2.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for i filter.",
+        "mode": "NULLABLE",
+        "name": "i_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of i_fpFluxMean.",
+        "mode": "NULLABLE",
+        "name": "i_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for z filter.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of z_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of z_psfFlux.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic for the scatter of z_psfFlux around z_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points used to compute z_psfFluxChi2.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for z filter.",
+        "mode": "NULLABLE",
+        "name": "z_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of z_fpFluxMean.",
+        "mode": "NULLABLE",
+        "name": "z_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for y filter.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of y_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of y_psfFlux.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic for the scatter of y_psfFlux around y_psfFluxMean.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points used to compute y_psfFluxChi2.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for y filter.",
+        "mode": "NULLABLE",
+        "name": "y_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of y_fpFluxMean.",
+        "mode": "NULLABLE",
+        "name": "y_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for u filter.",
+        "mode": "NULLABLE",
+        "name": "u_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of u_scienceFluxMean.",
+        "mode": "NULLABLE",
+        "name": "u_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of u_scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "u_scienceFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for g filter.",
+        "mode": "NULLABLE",
+        "name": "g_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of g_scienceFluxMean.",
+        "mode": "NULLABLE",
+        "name": "g_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of g_scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "g_scienceFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for r filter.",
+        "mode": "NULLABLE",
+        "name": "r_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of r_scienceFluxMean.",
+        "mode": "NULLABLE",
+        "name": "r_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of r_scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "r_scienceFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for i filter.",
+        "mode": "NULLABLE",
+        "name": "i_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of i_scienceFluxMean.",
+        "mode": "NULLABLE",
+        "name": "i_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of i_scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "i_scienceFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for z filter.",
+        "mode": "NULLABLE",
+        "name": "z_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of z_scienceFluxMean.",
+        "mode": "NULLABLE",
+        "name": "z_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of z_scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "z_scienceFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for y filter.",
+        "mode": "NULLABLE",
+        "name": "y_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of y_scienceFluxMean.",
+        "mode": "NULLABLE",
+        "name": "y_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of y_scienceFlux.",
+        "mode": "NULLABLE",
+        "name": "y_scienceFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Skewness of the u band fluxes.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxSkew",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed u band fluxes.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed u band fluxes.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between u band flux obsevations max(delta_flux/delta_time).",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the u band flux errors.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Skewness of the g band fluxes.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxSkew",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed g band fluxes.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed g band fluxes.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between g band flux obsevations max(delta_flux/delta_time).",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the g band flux errors.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Skewness of the r band fluxes.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxSkew",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed r band fluxes.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed r band fluxes.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between r band flux obsevations max(delta_flux/delta_time).",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the r band flux errors.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Skewness of the i band fluxes.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxSkew",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed i band fluxes.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed i band fluxes.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between i band flux obsevations max(delta_flux/delta_time).",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the i band flux errors.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Skewness of the z band fluxes.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxSkew",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed z band fluxes.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed z band fluxes.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between z band flux obsevations max(delta_flux/delta_time).",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the z band flux errors.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Skewness of the y band fluxes.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxSkew",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed y band fluxes.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed y band fluxes.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between y band flux obsevations max(delta_flux/delta_time).",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the y band flux errors.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Last time when non-forced DIASource was seen for this object.",
+        "mode": "REQUIRED",
+        "name": "lastNonForcedSource",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "Time of the first diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "firstDiaSourceMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Total number of DiaSources associated with this DiaObject.",
+        "mode": "REQUIRED",
+        "name": "nDiaSources",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "ssSource",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of the object.",
+        "mode": "NULLABLE",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Unique identifier of the observation.",
+        "mode": "NULLABLE",
+        "name": "diaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "MPC unique identifier of the observation.",
+        "mode": "NULLABLE",
+        "name": "mpcUniqueId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
+        "mode": "NULLABLE",
+        "name": "nearbyObj1",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
+        "mode": "NULLABLE",
+        "name": "nearbyObj2",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
+        "mode": "NULLABLE",
+        "name": "nearbyObj3",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
+        "mode": "NULLABLE",
+        "name": "nearbyObj4",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
+        "mode": "NULLABLE",
+        "name": "nearbyObj5",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Closest Objects (3 stars and 3 galaxies) in Level 2 database.",
+        "mode": "NULLABLE",
+        "name": "nearbyObj6",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Distances to nearbyObj.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjDist1",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Distances to nearbyObj.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjDist2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Distances to nearbyObj.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjDist3",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Distances to nearbyObj.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjDist4",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Distances to nearbyObj.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjDist5",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Distances to nearbyObj.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjDist6",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjLnP1",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjLnP2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjLnP3",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjLnP4",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjLnP5",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log of the probability that the observed DIAObject is the same as the nearby Object.",
+        "mode": "NULLABLE",
+        "name": "nearbyObjLnP6",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Ecliptic longitude.",
+        "mode": "NULLABLE",
+        "name": "eclipticLambda",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Ecliptic latitude.",
+        "mode": "NULLABLE",
+        "name": "eclipticBeta",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Galactic longitude.",
+        "mode": "NULLABLE",
+        "name": "galacticL",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Galactic latitute.",
+        "mode": "NULLABLE",
+        "name": "galacticB",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Phase angle.",
+        "mode": "NULLABLE",
+        "name": "phaseAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Heliocentric distance.",
+        "mode": "NULLABLE",
+        "name": "heliocentricDist",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Topocentric distace.",
+        "mode": "NULLABLE",
+        "name": "topocentricDist",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted magnitude.",
+        "mode": "NULLABLE",
+        "name": "predictedMagnitude",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Prediction uncertainty (1-sigma).",
+        "mode": "NULLABLE",
+        "name": "predictedMagnitudeSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Residual R.A. vs. ephemeris.",
+        "mode": "NULLABLE",
+        "name": "residualRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Residual Dec vs. ephemeris.",
+        "mode": "NULLABLE",
+        "name": "residualDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted R.A. uncertainty.",
+        "mode": "NULLABLE",
+        "name": "predictedRaSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted Dec uncertainty.",
+        "mode": "NULLABLE",
+        "name": "predictedDecSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted R.A./Dec covariance.",
+        "mode": "NULLABLE",
+        "name": "predictedRaDecCov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric X coordinate (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "heliocentricX",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Y coordinate (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "heliocentricY",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Z coordinate (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "heliocentricZ",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric X velocity (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "heliocentricVX",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Y velocity (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "heliocentricVY",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Z velocity (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "heliocentricVZ",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric X coordinate (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "topocentricX",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Y coordinate (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "topocentricY",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Z coordinate (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "topocentricZ",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric X velocity (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "topocentricVX",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Y velocity (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "topocentricVY",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Z velocity (at the emit time).",
+        "mode": "NULLABLE",
+        "name": "topocentricVZ",
+        "type": "FLOAT"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "MPCORB",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Number or provisional designation (in packed form).",
+        "mode": "NULLABLE",
+        "name": "mpcDesignation",
+        "type": "STRING"
+      },
+      {
+        "description": "LSST unique identifier (if observed by LSST).",
+        "mode": "NULLABLE",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Absolute magnitude, H.",
+        "mode": "NULLABLE",
+        "name": "mpcH",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Epoch (in MJD, .0 TT).",
+        "mode": "NULLABLE",
+        "name": "epoch",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean anomaly at the epoch, in degrees.",
+        "mode": "NULLABLE",
+        "name": "M",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Argument of perihelion, J2000.0 (degrees).",
+        "mode": "NULLABLE",
+        "name": "peri",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Longitude of the ascending node, J2000.0 (degrees).",
+        "mode": "NULLABLE",
+        "name": "node",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Inclination to the ecliptic, J2000.0 (degrees).",
+        "mode": "NULLABLE",
+        "name": "incl",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Orbital eccentricity.",
+        "mode": "NULLABLE",
+        "name": "e",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Semimajor axis (AU).",
+        "mode": "NULLABLE",
+        "name": "a",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Perihelion distance (AU).",
+        "mode": "NULLABLE",
+        "name": "q",
+        "type": "FLOAT"
+      },
+      {
+        "description": "MJD of pericentric passage.",
+        "mode": "NULLABLE",
+        "name": "t_p",
+        "type": "FLOAT"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "cutoutDifference",
+    "type": "BYTES"
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "cutoutScience",
+    "type": "BYTES"
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "cutoutTemplate",
+    "type": "BYTES"
+  }
+]

--- a/broker/setup_broker/lsst/templates/ps_lsst_lite_smt.yaml
+++ b/broker/setup_broker/lsst/templates/ps_lsst_lite_smt.yaml
@@ -13,23 +13,9 @@
 
           // Whitelist fields for diaObject
           const diaObjectFields = [
-            "diaObjectId", "lastNonForcedSource", "firstDiaSourceMjdTai",
+            "diaObjectId", "lastDiaSourceMjdTai", "firstDiaSourceMjdTai",
             "nDiaSources", "u_psfFluxErrMean", "g_psfFluxErrMean", "r_psfFluxErrMean",
             "i_psfFluxErrMean", "z_psfFluxErrMean", "y_psfFluxErrMean"
-          ];
-
-          // Whitelist fields for ssSource
-          const ssSourceFields = [
-            "ssObjectId", "nearbyObj1", "nearbyObj2", "nearbyObj3",
-            "nearbyObj4", "nearbyObj5", "nearbyObj6", "nearbyObj1Dist",
-            "nearbyObj2Dist", "nearbyObj3Dist", "nearbyObj4Dist",
-            "nearbyObj5Dist", "nearbyObj6Dist", "mpcUniqueId", "nearbyObjLnP1",
-            "nearbyObjLnP2", "nearbyObjLnP3", "nearbyObjLnP4", "nearbyObjLnP5",
-            "nearbyObjLnP6", "eclipticLambda", "eclipticBeta", "galacticL",
-            "galacticB", "phaseAngle", "heliocentricDist", "topocentricDist",
-            "heliocentricX", "heliocentricY", "heliocentricZ", "heliocentricVX",
-            "heliocentricVY", "heliocentricVZ", "topocentricX", "topocentricY",
-            "topocentricZ", "topocentricVX", "topocentricVY", "topocentricVZ"
           ];
 
           // Filter fields
@@ -54,14 +40,13 @@
           alertLite["diaSource"] = filterFields(alertLite["diaSource"], diaSourceFields);
           alertLite["prvDiaSources"] = filterList(alertLite["prvDiaSources"], diaSourceFields);
           alertLite["diaObject"] = filterFields(alertLite["diaObject"], diaObjectFields);
-          alertLite["ssSource"] = filterFields(alertLite["ssSource"], ssSourceFields);
 
           // Remove cutouts
           delete alertLite["cutoutDifference"];
           delete alertLite["cutoutScience"];
           delete alertLite["cutoutTemplate"];
 
-          // Keep observation_reason, target_name, prv_forced_sources and MPCORB unchanged
+          // Keep observation_reason, target_name, prv_forced_sources, ssSource, and MPCORB unchanged
           data["alert_lite"] = alertLite;
           message.data = JSON.stringify(data);
           return message;

--- a/broker/setup_broker/lsst/templates/ps_lsst_lite_smt.yaml
+++ b/broker/setup_broker/lsst/templates/ps_lsst_lite_smt.yaml
@@ -13,24 +13,23 @@
 
           // Whitelist fields for diaObject
           const diaObjectFields = [
-            "diaObjectId", "nearbyObj1", "nearbyObj2", "nearbyObj3",
-            "nearbyObj1Dist", "nearbyObj2Dist", "nearbyObj3Dist",
-            "nearbyObj1LnP", "nearbyObj2LnP", "nearbyObj3LnP",
-            "u_psfFluxErrMean", "g_psfFluxErrMean", "r_psfFluxErrMean",
+            "diaObjectId", "lastNonForcedSource", "firstDiaSourceMjdTai",
+            "nDiaSources", "u_psfFluxErrMean", "g_psfFluxErrMean", "r_psfFluxErrMean",
             "i_psfFluxErrMean", "z_psfFluxErrMean", "y_psfFluxErrMean"
           ];
 
-          // Whitelist fields for ssObject
-          const ssObjectFields = [
-            "ssObjectId", "firstObservationDate", "arc", "numObs", "MOID",
-            "MOIDEclipticLongitude", "MOIDDeltaV",
-            "u_H", "u_HErr", "u_Chi2",
-            "g_H", "g_HErr", "g_Chi2",
-            "r_H", "r_HErr", "r_Chi2",
-            "i_H", "i_HErr", "i_Chi2",
-            "z_H", "z_HErr", "z_Chi2",
-            "y_H", "y_HErr", "y_Chi2",
-            "medianExtendedness"
+          // Whitelist fields for ssSource
+          const ssSourceFields = [
+            "ssObjectId", "nearbyObj1", "nearbyObj2", "nearbyObj3",
+            "nearbyObj4", "nearbyObj5", "nearbyObj6", "nearbyObj1Dist",
+            "nearbyObj2Dist", "nearbyObj3Dist", "nearbyObj4Dist",
+            "nearbyObj5Dist", "nearbyObj6Dist", "mpcUniqueId", "nearbyObjLnP1",
+            "nearbyObjLnP2", "nearbyObjLnP3", "nearbyObjLnP4", "nearbyObjLnP5",
+            "nearbyObjLnP6", "eclipticLambda", "eclipticBeta", "galacticL",
+            "galacticB", "phaseAngle", "heliocentricDist", "topocentricDist",
+            "heliocentricX", "heliocentricY", "heliocentricZ", "heliocentricVX",
+            "heliocentricVY", "heliocentricVZ", "topocentricX", "topocentricY",
+            "topocentricZ", "topocentricVX", "topocentricVY", "topocentricVZ"
           ];
 
           // Filter fields
@@ -55,14 +54,14 @@
           alertLite["diaSource"] = filterFields(alertLite["diaSource"], diaSourceFields);
           alertLite["prvDiaSources"] = filterList(alertLite["prvDiaSources"], diaSourceFields);
           alertLite["diaObject"] = filterFields(alertLite["diaObject"], diaObjectFields);
-          alertLite["ssObject"] = filterFields(alertLite["ssObject"], ssObjectFields);
+          alertLite["ssSource"] = filterFields(alertLite["ssSource"], ssSourceFields);
 
           // Remove cutouts
           delete alertLite["cutoutDifference"];
           delete alertLite["cutoutScience"];
           delete alertLite["cutoutTemplate"];
 
-          // Keep prv_forced_sources and prv_nondetect_limits unchanged
+          // Keep observation_reason, target_name, prv_forced_sources and MPCORB unchanged
           data["alert_lite"] = alertLite;
           message.data = JSON.stringify(data);
           return message;


### PR DESCRIPTION
## Summary of Changes:

### Changed

- `setup_broker/lsst/templates/ps_lsst_lite_smt.yaml`
     - Updated functions used to specify which fields will be present in lite LSST alerts. A draft of the [LSST alert schema v8_0](https://github.com/lsst/alert_packet/tree/tickets/DM-50837/python/lsst/alert/packet/schema/8/0) is currently available
- `setup_broker/lsst/setup_broker.sh`
     - Updated the default value of `schema_version` to 8.0

### Added

- `setup_broker/lsst/templates`
     - `bq_lsst_alerts_v8_0_schema.json`