### PR TITLE
Create a daily partition for the LSST alerts table

### DIFF
--- a/broker/setup_broker/lsst/setup_broker.sh
+++ b/broker/setup_broker/lsst/setup_broker.sh
@@ -86,7 +86,7 @@ manage_resources() {
         else
             echo "${bq_dataset} already exists."
         fi
-        (cd templates && bq mk --table "${PROJECT_ID}:${bq_dataset}.${bq_table_alerts}" "bq_${survey}_${bq_table_alerts}_schema.json") || exit 5
+        (cd templates && bq mk --table --time_partitioning_type=DAY "${PROJECT_ID}:${bq_dataset}.${bq_table_alerts}" "bq_${survey}_${bq_table_alerts}_schema.json") || exit 5
         (cd templates && bq mk --table "${PROJECT_ID}:${bq_dataset}.${bq_table_supernnova}" "bq_${survey}_${bq_table_supernnova}_schema.json") || exit 5
         (cd templates && bq mk --table "${PROJECT_ID}:${bq_dataset}.${bq_table_variability}" "bq_${survey}_${bq_table_variability}_schema.json") || exit 5
         (cd templates && bq mk --table "${PROJECT_ID}:${bq_dataset}.${bq_table_upsilon}" "bq_${survey}_${bq_table_upsilon}_schema.json") || exit 5


### PR DESCRIPTION
## PR Summary

### Changed

- `/setup_broker/lsst/setup_broker.sh`
     - updated the `bq mk` command to include the flag: `--time_partitioning_type=DAY` for the LSST alerts table

Partitioning the alert table improves a query's performance by only scanning a portion of a table. The [maximum number of partitions allowed](https://cloud.google.com/bigquery/quotas#partitioned_tables) for a single BigQuery table is 10,000. Additional types of partitioning are outlined [here](https://cloud.google.com/bigquery/docs/partitioned-tables#types_of_partitioning).