### PR TITLE
Update the consumer's `ps-connector.properties` for LSST

### DIFF
--- a/broker/consumer/lsst/ps-connector.properties
+++ b/broker/consumer/lsst/ps-connector.properties
@@ -37,3 +37,6 @@ cps.topic=PS_TOPIC
 cps.project=PROJECT_ID
 # include Kafka topic, partition, offset, timestamp as msg attributes
 metadata.publish=true
+# specify the maximum number of messages that can be received for the messages on a topic partition before publishing
+# them to Cloud Pub/Sub
+maxBufferSize=50


### PR DESCRIPTION
## Summary of Changes

This PR addresses the following error message that was preventing LSST alerts from being publish to the `lsst-alerts_raw` topic.

```
INVALID_ARGUMENT: The value for request_size is too large. You passed 10000321 in the request, but the maximum value is 10000000.
```

### Added

- Defined a ceiling for the maximum number of messages that can be received for the messages on a topic partition before publishing them to Cloud Pub/Sub
     - `maxBufferSize=50`