### PR TITLE
Update pipelines for LSST schema v10_0

### DIFF
--- a/broker/consumer/lsst/vm_startup.sh
+++ b/broker/consumer/lsst/vm_startup.sh
@@ -44,7 +44,7 @@ fi
 ) || exit
 
 #--- Set the topic names to the "FORCE" metadata attributes if exist, else defaults
-KAFKA_TOPIC_DEFAULT="lsst-alerts-v9.0"
+KAFKA_TOPIC_DEFAULT="lsst-alerts-v10.0"
 KAFKA_TOPIC="${KAFKA_TOPIC_FORCE:-${KAFKA_TOPIC_DEFAULT}}"
 PS_TOPIC="${PS_TOPIC_FORCE:-${PS_TOPIC_DEFAULT}}"
 # set VM metadata, just for clarity and easy viewing

--- a/broker/setup_broker/lsst/setup_broker.sh
+++ b/broker/setup_broker/lsst/setup_broker.sh
@@ -8,7 +8,7 @@ testid="${1:-test}"
 teardown="${2:-False}"
 # name of the survey this broker instance will ingest
 survey="${3:-lsst}"
-schema_version="${4:-9.0}"
+schema_version="${4:-10.0}"
 versiontag=v$(echo "${schema_version}" | tr . _) # 9.0 -> v9_0
 region="${5:-us-central1}"
 zone="${region}-a"  # just use zone "a" instead of adding another script arg

--- a/broker/setup_broker/lsst/templates/bq_lsst_alerts_v10_0_schema.json
+++ b/broker/setup_broker/lsst/templates/bq_lsst_alerts_v10_0_schema.json
@@ -1,0 +1,2396 @@
+[
+  {
+    "description": "Identifier of the triggering DiaSource",
+    "mode": "REQUIRED",
+    "name": "diaSourceId",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Scheduler reason for the image containing this diaSource (RTN-097).",
+    "mode": "NULLABLE",
+    "name": "observation_reason",
+    "type": "STRING"
+  },
+  {
+    "description": "Scheduler target for the image containing this diaSource (RTN-097).",
+    "mode": "NULLABLE",
+    "name": "target_name",
+    "type": "STRING"
+  },
+  {
+    "description": "",
+    "mode": "REQUIRED",
+    "name": "diaSource",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of this DiaSource.",
+        "mode": "REQUIRED",
+        "name": "diaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the visit where this diaSource was measured.",
+        "mode": "REQUIRED",
+        "name": "visit",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the detector where this diaSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes.",
+        "mode": "REQUIRED",
+        "name": "detector",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the diaObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the ssObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the parent diaSource this diaSource has been deblended from, if any.",
+        "mode": "NULLABLE",
+        "name": "parentDiaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time [d].",
+        "mode": "REQUIRED",
+        "name": "midpointMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of the center of this diaSource [deg].",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of ra [deg].",
+        "mode": "NULLABLE",
+        "name": "raErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the center of this diaSource [deg].",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dec [deg].",
+        "mode": "NULLABLE",
+        "name": "decErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Covariance between ra and dec [deg**2].",
+        "mode": "NULLABLE",
+        "name": "ra_dec_Cov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "x position computed by a centroiding algorithm [pixel].",
+        "mode": "REQUIRED",
+        "name": "x",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of x [pixel].",
+        "mode": "NULLABLE",
+        "name": "xErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "y position computed by a centroiding algorithm [pixel].",
+        "mode": "REQUIRED",
+        "name": "y",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of y [pixel].",
+        "mode": "NULLABLE",
+        "name": "yErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General centroid algorithm failure flag; set if anything went wrong when fitting the centroid. Another centroid flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "centroid_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux in a 12 pixel radius aperture on the difference image [nJy].",
+        "mode": "NULLABLE",
+        "name": "apFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of apFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "apFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General aperture flux algorithm failure flag; set if anything went wrong when measuring aperture fluxes. Another apFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Aperture did not fit within measurement image.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag_apertureTruncated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Source was detected as significantly negative.",
+        "mode": "NULLABLE",
+        "name": "isNegative",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "The signal-to-noise ratio at which this source was detected in the difference image.",
+        "mode": "NULLABLE",
+        "name": "snr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
+        "mode": "NULLABLE",
+        "name": "psfFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "psfFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log likelihood of the observed data given the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfLnL",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the point source model fit.",
+        "mode": "NULLABLE",
+        "name": "psfChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Failure to derive linear least-squares fit of psf model. Another psfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Object was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of centroid for trailed source model [deg].",
+        "mode": "NULLABLE",
+        "name": "trailRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailRa [deg].",
+        "mode": "NULLABLE",
+        "name": "trailRaErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of centroid for trailed source model [deg].",
+        "mode": "NULLABLE",
+        "name": "trailDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailDec [deg].",
+        "mode": "NULLABLE",
+        "name": "trailDecErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of trail length [arcsec].",
+        "mode": "NULLABLE",
+        "name": "trailLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailLength [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailLengthErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing) [deg].",
+        "mode": "NULLABLE",
+        "name": "trailAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailAngle [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailAngleErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the trailed source model fit.",
+        "mode": "NULLABLE",
+        "name": "trailChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "This flag is set if a trailed source extends onto or past edge pixels.",
+        "mode": "NULLABLE",
+        "name": "trail_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleMeanFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiff",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleFluxDiff [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiffErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the lobe separation in dipole model [arcsec].",
+        "mode": "NULLABLE",
+        "name": "dipoleLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe) [deg].",
+        "mode": "NULLABLE",
+        "name": "dipoleAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the model fit.",
+        "mode": "NULLABLE",
+        "name": "dipoleChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the model.",
+        "mode": "NULLABLE",
+        "name": "dipoleNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position [nJy].",
+        "mode": "NULLABLE",
+        "name": "scienceFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of scienceFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "scienceFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux on science image was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position [nJy].",
+        "mode": "NULLABLE",
+        "name": "templateFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of templateFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "templateFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixx",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "iyy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixxPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "iyyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General source shape algorithm failure flag; set if anything went wrong when measuring the shape. Another shape flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "shape_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "No pixels to measure shape.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_no_pixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Center not contained in footprint bounding box.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_not_contained",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This source is a parent source; we should only be measuring on deblended children in difference imaging.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_parent_source",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "A measure of extendedness, computed by comparing an object's moment-based traced radius to the PSF moments. extendedness = 1 implies a high degree of confidence that the source is extended. extendedness = 0 implies a high degree of confidence that the source is point-like.",
+        "mode": "NULLABLE",
+        "name": "extendedness",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Probability (0-1) that the diaSource is astrophysical, derived from a machine learning model.",
+        "mode": "NULLABLE",
+        "name": "reliability",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Filter band this source was observed with.",
+        "mode": "NULLABLE",
+        "name": "band",
+        "type": "STRING"
+      },
+      {
+        "description": "Source well fit by a dipole.",
+        "mode": "NULLABLE",
+        "name": "isDipole",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Attempted to fit a dipole model to this source.",
+        "mode": "NULLABLE",
+        "name": "dipoleFitAttempted",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Time when the image was processed and this DiaSource record was generated, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "timeProcessedMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Time when this record was marked invalid, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "timeWithdrawnMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Size of the square bounding box that fully contains the detection footprint [pixel].",
+        "mode": "NULLABLE",
+        "name": "bboxSize",
+        "type": "INTEGER"
+      },
+      {
+        "description": "General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Bad pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_bad",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_cr",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_crCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image).",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the source footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodata",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodataCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource center is off image.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_offimage",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource's footprint includes suspect pixels.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspect",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Suspect pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspectCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streak",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streakCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injectedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_template",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_templateCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This flag is set if the source is part of a glint trail.",
+        "mode": "NULLABLE",
+        "name": "glint_trail",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "prvDiaSources",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of this DiaSource.",
+        "mode": "REQUIRED",
+        "name": "diaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the visit where this diaSource was measured.",
+        "mode": "REQUIRED",
+        "name": "visit",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the detector where this diaSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes.",
+        "mode": "REQUIRED",
+        "name": "detector",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the diaObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the ssObject this source was associated with, if any. If not, it is set to NULL (each diaSource will be associated with either a diaObject or ssObject).",
+        "mode": "NULLABLE",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the parent diaSource this diaSource has been deblended from, if any.",
+        "mode": "NULLABLE",
+        "name": "parentDiaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Effective mid-visit time for this diaSource, expressed as Modified Julian Date, International Atomic Time [d].",
+        "mode": "REQUIRED",
+        "name": "midpointMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of the center of this diaSource [deg].",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of ra [deg].",
+        "mode": "NULLABLE",
+        "name": "raErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the center of this diaSource [deg].",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dec [deg].",
+        "mode": "NULLABLE",
+        "name": "decErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Covariance between ra and dec [deg**2].",
+        "mode": "NULLABLE",
+        "name": "ra_dec_Cov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "x position computed by a centroiding algorithm [pixel].",
+        "mode": "REQUIRED",
+        "name": "x",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of x [pixel].",
+        "mode": "NULLABLE",
+        "name": "xErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "y position computed by a centroiding algorithm [pixel].",
+        "mode": "REQUIRED",
+        "name": "y",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of y [pixel].",
+        "mode": "NULLABLE",
+        "name": "yErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General centroid algorithm failure flag; set if anything went wrong when fitting the centroid. Another centroid flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "centroid_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux in a 12 pixel radius aperture on the difference image [nJy].",
+        "mode": "NULLABLE",
+        "name": "apFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of apFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "apFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General aperture flux algorithm failure flag; set if anything went wrong when measuring aperture fluxes. Another apFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Aperture did not fit within measurement image.",
+        "mode": "NULLABLE",
+        "name": "apFlux_flag_apertureTruncated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Source was detected as significantly negative.",
+        "mode": "NULLABLE",
+        "name": "isNegative",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "The signal-to-noise ratio at which this source was detected in the difference image.",
+        "mode": "NULLABLE",
+        "name": "snr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Flux for Point Source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
+        "mode": "NULLABLE",
+        "name": "psfFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "psfFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Natural log likelihood of the observed data given the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfLnL",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the point source model fit.",
+        "mode": "NULLABLE",
+        "name": "psfChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the point source model.",
+        "mode": "NULLABLE",
+        "name": "psfNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Failure to derive linear least-squares fit of psf model. Another psfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Object was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "psfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Flux for a trailed source model. Note this actually measures the flux difference between the template and the visit image [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of centroid for trailed source model [deg].",
+        "mode": "NULLABLE",
+        "name": "trailRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailRa [deg].",
+        "mode": "NULLABLE",
+        "name": "trailRaErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of centroid for trailed source model [deg].",
+        "mode": "NULLABLE",
+        "name": "trailDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailDec [deg].",
+        "mode": "NULLABLE",
+        "name": "trailDecErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of trail length [arcsec].",
+        "mode": "NULLABLE",
+        "name": "trailLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailLength [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailLengthErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the trail direction (bearing) [deg].",
+        "mode": "NULLABLE",
+        "name": "trailAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of trailAngle [nJy].",
+        "mode": "NULLABLE",
+        "name": "trailAngleErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the trailed source model fit.",
+        "mode": "NULLABLE",
+        "name": "trailChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the trailed source model.",
+        "mode": "NULLABLE",
+        "name": "trailNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "This flag is set if a trailed source extends onto or past edge pixels.",
+        "mode": "NULLABLE",
+        "name": "trail_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Maximum likelihood value for the mean absolute flux of the two lobes for a dipole model [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleMeanFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleMeanFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the difference of absolute fluxes of the two lobes for a dipole model [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiff",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dipoleFluxDiff [nJy].",
+        "mode": "NULLABLE",
+        "name": "dipoleFluxDiffErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood value for the lobe separation in dipole model [arcsec].",
+        "mode": "NULLABLE",
+        "name": "dipoleLength",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum likelihood fit of the angle between the meridian through the centroid and the dipole direction (bearing, from negative to positive lobe) [deg].",
+        "mode": "NULLABLE",
+        "name": "dipoleAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Chi^2 statistic of the model fit.",
+        "mode": "NULLABLE",
+        "name": "dipoleChi2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of data points (pixels) used to fit the model.",
+        "mode": "NULLABLE",
+        "name": "dipoleNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at DiaSource position [nJy].",
+        "mode": "NULLABLE",
+        "name": "scienceFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Estimated uncertainty of scienceFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "scienceFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Forced PSF photometry on science image failed. Another forced_PsfFlux flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux on science image was too close to the edge of the image to use the full PSF model.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced PSF flux not enough non-rejected pixels in data to attempt the fit.",
+        "mode": "NULLABLE",
+        "name": "forced_PsfFlux_flag_noGoodPixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the template image centered at the DiaObject position [nJy].",
+        "mode": "NULLABLE",
+        "name": "templateFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of templateFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "templateFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixx",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "iyy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment of the source intensity [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixxPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "iyyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Adaptive second moment for the PSF [nJy.arcsec**2].",
+        "mode": "NULLABLE",
+        "name": "ixyPSF",
+        "type": "FLOAT"
+      },
+      {
+        "description": "General source shape algorithm failure flag; set if anything went wrong when measuring the shape. Another shape flag field should also be set to provide more information.",
+        "mode": "NULLABLE",
+        "name": "shape_flag",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "No pixels to measure shape.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_no_pixels",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Center not contained in footprint bounding box.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_not_contained",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This source is a parent source; we should only be measuring on deblended children in difference imaging.",
+        "mode": "NULLABLE",
+        "name": "shape_flag_parent_source",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "A measure of extendedness, computed by comparing an object's moment-based traced radius to the PSF moments. extendedness = 1 implies a high degree of confidence that the source is extended. extendedness = 0 implies a high degree of confidence that the source is point-like.",
+        "mode": "NULLABLE",
+        "name": "extendedness",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Probability (0-1) that the diaSource is astrophysical, derived from a machine learning model.",
+        "mode": "NULLABLE",
+        "name": "reliability",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Filter band this source was observed with.",
+        "mode": "NULLABLE",
+        "name": "band",
+        "type": "STRING"
+      },
+      {
+        "description": "Source well fit by a dipole.",
+        "mode": "NULLABLE",
+        "name": "isDipole",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Attempted to fit a dipole model to this source.",
+        "mode": "NULLABLE",
+        "name": "dipoleFitAttempted",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Time when the image was processed and this DiaSource record was generated, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "timeProcessedMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Time when this record was marked invalid, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "timeWithdrawnMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Size of the square bounding box that fully contains the detection footprint [pixel].",
+        "mode": "NULLABLE",
+        "name": "bboxSize",
+        "type": "INTEGER"
+      },
+      {
+        "description": "General pixel flags failure; set if anything went wrong when setting pixels flags from this footprint's mask. This implies that some pixelFlags for this source may be incorrectly set to False.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Bad pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_bad",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_cr",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Cosmic ray in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_crCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Some of the source footprint is outside usable exposure region (masked EDGE or centroid off image).",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_edge",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the source footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodata",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "NO_DATA pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_nodataCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Interpolated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_interpolatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource center is off image.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_offimage",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturated",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Saturated pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_saturatedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "DiaSource's footprint includes suspect pixels.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspect",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Suspect pixel in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_suspectCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streak",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Streak in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_streakCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injectedCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the DiaSource footprint.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_template",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "Template injection in the 3x3 region around the centroid.",
+        "mode": "NULLABLE",
+        "name": "pixelFlags_injected_templateCenter",
+        "type": "BOOLEAN"
+      },
+      {
+        "description": "This flag is set if the source is part of a glint trail.",
+        "mode": "NULLABLE",
+        "name": "glint_trail",
+        "type": "BOOLEAN"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "REPEATED",
+    "name": "prvDiaForcedSources",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique id.",
+        "mode": "REQUIRED",
+        "name": "diaForcedSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the DiaObject that this DiaForcedSource was associated with.",
+        "mode": "REQUIRED",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Right ascension coordinate of the position of the DiaObject [deg].",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the position of the DiaObject [deg].",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Id of the visit where this forcedSource was measured.",
+        "mode": "REQUIRED",
+        "name": "visit",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Id of the detector where this forcedSource was measured. Datatype short instead of byte because of DB concerns about unsigned bytes.",
+        "mode": "REQUIRED",
+        "name": "detector",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Point Source model flux [nJy].",
+        "mode": "NULLABLE",
+        "name": "psfFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "psfFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Effective mid-visit time for this diaForcedSource, expressed as Modified Julian Date, International Atomic Time [d].",
+        "mode": "REQUIRED",
+        "name": "midpointMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Forced photometry flux for a point source model measured on the visit image centered at the DiaObject position [nJy].",
+        "mode": "NULLABLE",
+        "name": "scienceFlux",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of scienceFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "scienceFluxErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Filter band this source was observed with.",
+        "mode": "NULLABLE",
+        "name": "band",
+        "type": "STRING"
+      },
+      {
+        "description": "Time when this record was generated, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "timeProcessedMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Time when this record was marked invalid, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "timeWithdrawnMjdTai",
+        "type": "FLOAT"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "diaObject",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of this DiaObject.",
+        "mode": "REQUIRED",
+        "name": "diaObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Processing time when validity of this diaObject starts, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "REQUIRED",
+        "name": "validityStartMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Right ascension coordinate of the position of the object [deg].",
+        "mode": "REQUIRED",
+        "name": "ra",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of ra [deg].",
+        "mode": "NULLABLE",
+        "name": "raErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Declination coordinate of the position of the object [deg].",
+        "mode": "REQUIRED",
+        "name": "dec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty of dec [deg].",
+        "mode": "NULLABLE",
+        "name": "decErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Covariance between ra and dec [deg**2].",
+        "mode": "NULLABLE",
+        "name": "ra_dec_Cov",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for u filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of u_psfFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of u_psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of u-band data points.",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for u filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of u_fpFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for g filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of g_psfFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of g_psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of g-band data points.",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for g filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of g_fpFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for r filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of r_psfFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of r_psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of r-band data points.",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for r filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of r_fpFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for i filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of i_psfFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of i_psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of i-band data points.",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for i filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of i_fpFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for z filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of z_psfFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of z_psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of z-band data points.",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for z filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of z_fpFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean point-source model magnitude for y filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of y_psfFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard deviation of the distribution of y_psfFlux [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxSigma",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The number of y-band data points.",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxNdata",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for y filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_fpFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of y_fpFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_fpFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for u filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of u_scienceFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for g filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of g_scienceFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for r filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of r_scienceFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for i filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of i_scienceFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for z filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of z_scienceFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Weighted mean forced photometry flux for y filter [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_scienceFluxMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Standard error of y_scienceFluxMean [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_scienceFluxMeanErr",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed u band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed u band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between u band flux obsevations max(delta_flux/delta_time) [nJy/d].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the u band flux errors [nJy].",
+        "mode": "NULLABLE",
+        "name": "u_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed g band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed g band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between g band flux obsevations max(delta_flux/delta_time) [nJy/d].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the g band flux errors [nJy].",
+        "mode": "NULLABLE",
+        "name": "g_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed r band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed r band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between r band flux obsevations max(delta_flux/delta_time) [nJy/d].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the r band flux errors [nJy].",
+        "mode": "NULLABLE",
+        "name": "r_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed i band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed i band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between i band flux obsevations max(delta_flux/delta_time) [nJy/d].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the i band flux errors [nJy].",
+        "mode": "NULLABLE",
+        "name": "i_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed z band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed z band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between z band flux obsevations max(delta_flux/delta_time) [nJy/d].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the z band flux errors [nJy].",
+        "mode": "NULLABLE",
+        "name": "z_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum observed y band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMin",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum observed y band fluxes [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMax",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Maximum slope between y band flux obsevations max(delta_flux/delta_time) [nJy/d].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxMaxSlope",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean of the y band flux errors [nJy].",
+        "mode": "NULLABLE",
+        "name": "y_psfFluxErrMean",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Time of the first diaSource, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "firstDiaSourceMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Time of the most recent non-forced DIASource for this object, expressed as Modified Julian Date, International Atomic Time.",
+        "mode": "NULLABLE",
+        "name": "lastDiaSourceMjdTai",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Total number of DiaSources associated with this DiaObject.",
+        "mode": "REQUIRED",
+        "name": "nDiaSources",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "ssSource",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Unique identifier of the observation (matching DiaSource.diaSourceId).",
+        "mode": "REQUIRED",
+        "name": "diaSourceId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Unique LSST identifier of the Solar System object.",
+        "mode": "REQUIRED",
+        "name": "ssObjectId",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The unpacked primary provisional designation for this object.",
+        "mode": "NULLABLE",
+        "name": "designation",
+        "type": "STRING"
+      },
+      {
+        "description": "Ecliptic longitude, converted from the observed coordinates.",
+        "mode": "REQUIRED",
+        "name": "eclLambda",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Ecliptic latitude, converted from the observed coordinates.",
+        "mode": "REQUIRED",
+        "name": "eclBeta",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Galactic longitude, converted from the observed coordinates.",
+        "mode": "REQUIRED",
+        "name": "galLon",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Galactic latitude, converted from the observed coordinates.",
+        "mode": "REQUIRED",
+        "name": "galLat",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Solar elongation of the object at the time of observation.",
+        "mode": "NULLABLE",
+        "name": "elongation",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Phase angle between the Sun, object, and observer.",
+        "mode": "NULLABLE",
+        "name": "phaseAngle",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Topocentric distance (delta) at light-emission time.",
+        "mode": "NULLABLE",
+        "name": "topoRange",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Topocentric radial (line-of-sight) velocity (deldot); positive values indicate motion away from the observer.",
+        "mode": "NULLABLE",
+        "name": "topoRangeRate",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Heliocentric distance (r) at light-emission time.",
+        "mode": "NULLABLE",
+        "name": "helioRange",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Heliocentric radial velocity (rdot); positive values indicate motion away from the Sun.",
+        "mode": "NULLABLE",
+        "name": "helioRangeRate",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted ICRS right ascension from the orbit in mpc_orbits.",
+        "mode": "NULLABLE",
+        "name": "ephRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted ICRS declination from the orbit in mpc_orbits.",
+        "mode": "NULLABLE",
+        "name": "ephDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted magnitude in V band, computed from mpc_orbits data including the mpc_orbits-provided (H, G) estimates\n",
+        "mode": "NULLABLE",
+        "name": "ephVmag",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Total predicted on-sky angular rate of motion.",
+        "mode": "NULLABLE",
+        "name": "ephRate",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted on-sky angular rate in the R.A. direction (includes the cos(dec) factor).",
+        "mode": "NULLABLE",
+        "name": "ephRateRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Predicted on-sky angular rate in the declination direction.",
+        "mode": "NULLABLE",
+        "name": "ephRateDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Total observed versus predicted angular separation on the sky.",
+        "mode": "NULLABLE",
+        "name": "ephOffset",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Offset between observed and predicted position in the R.A. direction (includes cos(dec) term).",
+        "mode": "NULLABLE",
+        "name": "ephOffsetRa",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Offset between observed and predicted position in declination.",
+        "mode": "NULLABLE",
+        "name": "ephOffsetDec",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Offset between observed and predicted position in the along-track direction on the sky.",
+        "mode": "NULLABLE",
+        "name": "ephOffsetAlongTrack",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Offset between observed and predicted position in the cross-track direction on the sky.",
+        "mode": "NULLABLE",
+        "name": "ephOffsetCrossTrack",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric X coordinate at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "helio_x",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Y coordinate at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "helio_y",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Z coordinate at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "helio_z",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric X velocity at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "helio_vx",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Y velocity at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "helio_vy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian heliocentric Z velocity at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "helio_vz",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The magnitude of the heliocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz).",
+        "mode": "NULLABLE",
+        "name": "helio_vtot",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric X coordinate at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "topo_x",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Y coordinate at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "topo_y",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Z coordinate at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "topo_z",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric X velocity at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "topo_vx",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Y velocity at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "topo_vy",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Cartesian topocentric Z velocity at light-emission time (ICRS).",
+        "mode": "NULLABLE",
+        "name": "topo_vz",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The magnitude of the topocentric velocity vector, sqrt(vx*vx + vy*vy + vz*vz).",
+        "mode": "NULLABLE",
+        "name": "topo_vtot",
+        "type": "FLOAT"
+      },
+      {
+        "description": "The rank of the diaSourceId-identified source in terms of its closeness to the predicted SSO position.  If diaSourceId is the nearest DiaSource to this SSO prediction, diaSourceDistanceRank=1 would be set. If it is the second nearest, it would be 2, etc.",
+        "mode": "NULLABLE",
+        "name": "diaDistanceRank",
+        "type": "INTEGER"
+      }
+    ]
+  },
+  {
+    "description": "",
+    "mode": "NULLABLE",
+    "name": "mpc_orbits",
+    "type": "RECORD",
+    "fields": [
+      {
+        "description": "Internal ID (generally not seen/used by the user)",
+        "mode": "REQUIRED",
+        "name": "id",
+        "type": "INTEGER"
+      },
+      {
+        "description": "The primary provisional designation in unpacked form (e.g. 2008 AB).",
+        "mode": "REQUIRED",
+        "name": "designation",
+        "type": "STRING"
+      },
+      {
+        "description": "The primary provisional designation in packed form (e.g. K08A00B)",
+        "mode": "REQUIRED",
+        "name": "packed_primary_provisional_designation",
+        "type": "STRING"
+      },
+      {
+        "description": "The primary provisional designation in unpacked form (e.g. 2008 AB)",
+        "mode": "REQUIRED",
+        "name": "unpacked_primary_provisional_designation",
+        "type": "STRING"
+      },
+      {
+        "description": "Details of the orbit solution in JSON form",
+        "mode": "NULLABLE",
+        "name": "mpc_orb_jsonb",
+        "type": "STRING"
+      },
+      {
+        "description": "When this row was created",
+        "mode": "NULLABLE",
+        "name": "created_at",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "When this row was updated",
+        "mode": "NULLABLE",
+        "name": "updated_at",
+        "type": "TIMESTAMP"
+      },
+      {
+        "description": "Orbit Type (Integer)",
+        "mode": "NULLABLE",
+        "name": "orbit_type_int",
+        "type": "INTEGER"
+      },
+      {
+        "description": "U parameter",
+        "mode": "NULLABLE",
+        "name": "u_param",
+        "type": "INTEGER"
+      },
+      {
+        "description": "number of oppositions",
+        "mode": "NULLABLE",
+        "name": "nopp",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Arc length over total observations [days]",
+        "mode": "NULLABLE",
+        "name": "arc_length_total",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Arc length over total observations *selected* [days]",
+        "mode": "NULLABLE",
+        "name": "arc_length_sel",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Total number of all observations (optical + radar) available",
+        "mode": "NULLABLE",
+        "name": "nobs_total",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Total number of all observations (optical + radar) selected for use in orbit fitting",
+        "mode": "NULLABLE",
+        "name": "nobs_total_sel",
+        "type": "INTEGER"
+      },
+      {
+        "description": "Semi Major Axis [au]",
+        "mode": "NULLABLE",
+        "name": "a",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Pericenter Distance [au]",
+        "mode": "NULLABLE",
+        "name": "q",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Eccentricity",
+        "mode": "NULLABLE",
+        "name": "e",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Inclination [degrees]",
+        "mode": "NULLABLE",
+        "name": "i",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Longitude of Ascending Node [degrees]",
+        "mode": "NULLABLE",
+        "name": "node",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Argument of Pericenter [degrees]",
+        "mode": "NULLABLE",
+        "name": "argperi",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Time from Pericenter Passage [days]",
+        "mode": "NULLABLE",
+        "name": "peri_time",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Yarkovsky Component [10^(-10)*au/day^2]",
+        "mode": "NULLABLE",
+        "name": "yarkovsky",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Solar-Radiation Pressure Component [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "srp",
+        "type": "FLOAT"
+      },
+      {
+        "description": "A1 non-grav components [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "a1",
+        "type": "FLOAT"
+      },
+      {
+        "description": "A2 non-grav components [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "a2",
+        "type": "FLOAT"
+      },
+      {
+        "description": "A3 non-grav components [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "a3",
+        "type": "FLOAT"
+      },
+      {
+        "description": "DT non-grav component",
+        "mode": "NULLABLE",
+        "name": "dt",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Mean Anomaly [degrees]",
+        "mode": "NULLABLE",
+        "name": "mean_anomaly",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Orbital Period [days]",
+        "mode": "NULLABLE",
+        "name": "period",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Orbital Mean Motion [degrees per day]",
+        "mode": "NULLABLE",
+        "name": "mean_motion",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Semi Major Axis [au]",
+        "mode": "NULLABLE",
+        "name": "a_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Pericenter Distance [au]",
+        "mode": "NULLABLE",
+        "name": "q_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Eccentricity",
+        "mode": "NULLABLE",
+        "name": "e_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Inclination [degrees]",
+        "mode": "NULLABLE",
+        "name": "i_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Longitude of Ascending Node [degrees]",
+        "mode": "NULLABLE",
+        "name": "node_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Argument of Pericenter [degrees]",
+        "mode": "NULLABLE",
+        "name": "argperi_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Time from Pericenter Passage [days]",
+        "mode": "NULLABLE",
+        "name": "peri_time_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Yarkovsky Component [10^(-10)*au/day^2]",
+        "mode": "NULLABLE",
+        "name": "yarkovsky_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Solar-Radiation Pressure Component [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "srp_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on A1 non-grav components [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "a1_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on A2 non-grav components [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "a2_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on A3 non-grav components [m^2/ton]",
+        "mode": "NULLABLE",
+        "name": "a3_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on DT non-grav component",
+        "mode": "NULLABLE",
+        "name": "dt_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Mean Anomaly [degrees]",
+        "mode": "NULLABLE",
+        "name": "mean_anomaly_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Orbital Period [days]",
+        "mode": "NULLABLE",
+        "name": "period_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Uncertainty on Orbital Mean Motion [degrees per day]",
+        "mode": "NULLABLE",
+        "name": "mean_motion_unc",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Epoch of the Orbfit-Solution in MJD",
+        "mode": "NULLABLE",
+        "name": "epoch_mjd",
+        "type": "FLOAT"
+      },
+      {
+        "description": "H-Magnitude",
+        "mode": "NULLABLE",
+        "name": "h",
+        "type": "FLOAT"
+      },
+      {
+        "description": "G-Slope Parameter",
+        "mode": "NULLABLE",
+        "name": "g",
+        "type": "FLOAT"
+      },
+      {
+        "description": "unnormalized rms of the fit [arcsec]",
+        "mode": "NULLABLE",
+        "name": "not_normalized_rms",
+        "type": "FLOAT"
+      },
+      {
+        "description": "rms of the fit [unitless]",
+        "mode": "NULLABLE",
+        "name": "normalized_rms",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Minimum Orbit Intersection Distance [au] with respect to the Earths Orbit",
+        "mode": "NULLABLE",
+        "name": "earth_moid",
+        "type": "FLOAT"
+      },
+      {
+        "description": "Date of the last orbit fit",
+        "mode": "NULLABLE",
+        "name": "fitting_datetime",
+        "type": "TIMESTAMP"
+      }
+    ]
+  },
+  {
+    "description": "HEALPix order 9 pixel index at the source’s right ascension (RA) and declination",
+    "mode": "REQUIRED",
+    "name": "healpix9",
+    "type": "INTEGER"
+  },
+  {
+    "description": "HEALPix order 19 pixel index at the source’s right ascension (RA) and declination",
+    "mode": "REQUIRED",
+    "name": "healpix19",
+    "type": "INTEGER"
+  },
+  {
+    "description": "HEALPix order 29 pixel index at the source’s right ascension (RA) and declination",
+    "mode": "REQUIRED",
+    "name": "healpix29",
+    "type": "INTEGER"
+  },
+  {
+    "description": "Kafka timestamp from originating LSST alert.",
+    "mode": "REQUIRED",
+    "name": "kafkaPublishTimestamp",
+    "type": "TIMESTAMP"
+  }
+]


### PR DESCRIPTION
The latest ([v10.0)](https://github.com/lsst/alert_packet/tree/main/python/lsst/alert/packet/schema/10/0) LSST alert schema has been announced and will be deployed into production tomorrow.

This PR:
- Updates the default Kafka topic for the LSST consumer
- Updates the default `schema_version` value in setup_broker.sh
- Adds the BQ table schema for v10_0