### PR TITLE
Update LSST Cloud Run requirements

### DIFF
--- a/broker/cloud_run/lsst/classify_snn/requirements.txt
+++ b/broker/cloud_run/lsst/classify_snn/requirements.txt
@@ -2,7 +2,7 @@ pandas==1.5.1
 numpy==1.23.3
 google-cloud-functions
 google-cloud-logging
-pittgoogle-client>=0.3.18
+pittgoogle-client>=0.3.20
 
 # for Cloud Run
 # https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service

--- a/broker/cloud_run/lsst/classify_upsilon/requirements.txt
+++ b/broker/cloud_run/lsst/classify_upsilon/requirements.txt
@@ -4,7 +4,7 @@
 # file (or packaged with the function) in the same directory as `main.py`
 
 google-cloud-logging
-pittgoogle-client>=0.3.18
+pittgoogle-client>=0.3.20
 upsilon
 # required by upsilon
 # https://github.com/dwkim78/upsilon?tab=readme-ov-file#1-dependency

--- a/broker/cloud_run/lsst/ps_to_storage/requirements.txt
+++ b/broker/cloud_run/lsst/ps_to_storage/requirements.txt
@@ -5,7 +5,7 @@
 
 google-cloud-logging
 google-cloud-storage
-pittgoogle-client>=0.3.18
+pittgoogle-client>=0.3.20
 
 # for Cloud Run
 # https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service

--- a/broker/cloud_run/lsst/variability/requirements.txt
+++ b/broker/cloud_run/lsst/variability/requirements.txt
@@ -4,7 +4,7 @@
 # file (or packaged with the function) in the same directory as `main.py`
 
 google-cloud-logging
-pittgoogle-client>=0.3.18
+pittgoogle-client>=0.3.20
 
 # for Cloud Run
 # https://cloud.google.com/run/docs/quickstarts/build-and-deploy/deploy-python-service


### PR DESCRIPTION
This PR updates the `requirements.txt` file for each LSST Cloud Run service to use `pittgoogle-client` >= 0.3.20