### PR TITLE
Update consumer VM scripts to accommodate new LSST Kafka broker

### DIFF
--- a/broker/consumer/lsst/admin.properties
+++ b/broker/consumer/lsst/admin.properties
@@ -3,7 +3,7 @@
 # In cases where we can connect without authentication (e.g., ZTF), this file is not used.
 # For config options, see https://kafka.apache.org/documentation/#adminclientconfigs
 
-bootstrap.servers=usdf-alert-stream-dev.lsst.cloud:9094
+bootstrap.servers=rubin-alert-stream-bootstrap.slac.stanford.edu:9094
 sasl.mechanism=SCRAM-SHA-512
 security.protocol=SASL_PLAINTEXT
 sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \

--- a/broker/consumer/lsst/admin.properties
+++ b/broker/consumer/lsst/admin.properties
@@ -7,5 +7,5 @@ bootstrap.servers=rubin-alert-stream-bootstrap.slac.stanford.edu:9094
 sasl.mechanism=SCRAM-SHA-512
 security.protocol=SASL_PLAINTEXT
 sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
-   username="pittgoogle-idfint"\
+   username="pittgoogle-usdf"\
    password="KAFKA_PASSWORD";

--- a/broker/consumer/lsst/psconnect-worker.properties
+++ b/broker/consumer/lsst/psconnect-worker.properties
@@ -31,7 +31,7 @@ sasl.mechanism=SCRAM-SHA-512
 sasl.kerberos.service.name=kafka
 security.protocol=SASL_PLAINTEXT
 sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
-   username="pittgoogle-idfint"\
+   username="pittgoogle-usdf"\
    password="KAFKA_PASSWORD";
 
 # settings with `consumer.` prefixes are passed through to the Kafka consumer

--- a/broker/consumer/lsst/psconnect-worker.properties
+++ b/broker/consumer/lsst/psconnect-worker.properties
@@ -3,7 +3,7 @@
 # For config options, see https://docs.confluent.io/platform/current/connect/references/allconfigs.html#worker-configuration-properties
 # See also: https://kafka.apache.org/documentation/#adminclientconfigs
 
-bootstrap.servers=usdf-alert-stream-dev.lsst.cloud:9094
+bootstrap.servers=rubin-alert-stream-bootstrap.slac.stanford.edu:9094
 plugin.path=/usr/local/share/kafka/plugins
 offset.storage.file.filename=/tmp/connect.offsets
 

--- a/broker/consumer/lsst/psconnect-worker.properties
+++ b/broker/consumer/lsst/psconnect-worker.properties
@@ -42,5 +42,5 @@ consumer.sasl.mechanism=SCRAM-SHA-512
 consumer.sasl.kerberos.service.name=kafka
 consumer.security.protocol=SASL_PLAINTEXT
 consumer.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
-   username="pittgoogle-idfint"\
+   username="pittgoogle-usdf"\
    password="KAFKA_PASSWORD";

--- a/broker/consumer/lsst/vm_startup.sh
+++ b/broker/consumer/lsst/vm_startup.sh
@@ -88,7 +88,7 @@ while [ "${alerts_flowing}" = false ]
 do
     # get list of topics and dump to file
     /bin/kafka-topics \
-        --bootstrap-server usdf-alert-stream-dev.lsst.cloud:9094 \
+        --bootstrap-server rubin-alert-stream-bootstrap.slac.stanford.edu:9094 \
         --list \
         --command-config "${workingdir}/admin.properties" \
         > "${fout_topics}"

--- a/broker/consumer/lsst/vm_startup.sh
+++ b/broker/consumer/lsst/vm_startup.sh
@@ -63,7 +63,7 @@ fout_topics="${workingdir}/list.topics"
     # define LSST-related parameters
     kafka_password="${survey}-${PROJECT_ID}-kafka-password"
     KAFKA_PASSWORD=$(gcloud secrets versions access latest --secret="${kafka_password}")
-    group_id="pittgoogle-idfint-kafka-pubsub-connector-${PROJECT_ID}"
+    group_id="pittgoogle-usdf-kafka-pubsub-connector-${PROJECT_ID}"
     # use test resources, if requested
     if [ "$testid" != "False" ]; then
         group_id="${group_id}-${testid}"

--- a/broker/setup_broker/lsst/setup_broker.sh
+++ b/broker/setup_broker/lsst/setup_broker.sh
@@ -8,8 +8,8 @@ testid="${1:-test}"
 teardown="${2:-False}"
 # name of the survey this broker instance will ingest
 survey="${3:-lsst}"
-schema_version="${4:-11.0}"
-versiontag=v$(echo "${schema_version}" | tr . _) # 11.0 -> v11_0
+schema_version="${4:-10.0}"
+versiontag=v$(echo "${schema_version}" | tr . _) # 9.0 -> v9_0
 region="${5:-us-central1}"
 zone="${region}-a"  # just use zone "a" instead of adding another script arg
 # get environment variables

--- a/broker/setup_broker/lsst/setup_broker.sh
+++ b/broker/setup_broker/lsst/setup_broker.sh
@@ -8,8 +8,8 @@ testid="${1:-test}"
 teardown="${2:-False}"
 # name of the survey this broker instance will ingest
 survey="${3:-lsst}"
-schema_version="${4:-10.0}"
-versiontag=v$(echo "${schema_version}" | tr . _) # 9.0 -> v9_0
+schema_version="${4:-11.0}"
+versiontag=v$(echo "${schema_version}" | tr . _) # 11.0 -> v11_0
 region="${5:-us-central1}"
 zone="${region}-a"  # just use zone "a" instead of adding another script arg
 # get environment variables


### PR DESCRIPTION
The Vera C. Rubin Observatory's Kafka alert stream is moving to a new production environment starting May 4th.  This PR updates our LSST broker instance's consumer VM's startup scripts to accommodate the new changes. These changes have been successfully tested.